### PR TITLE
Testing: Upgrade to Selenium v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,12 @@ jobs:
           --health-retries 5
 
       selenium:
-        image: selenium/standalone-firefox:3.141.59
+        image: selenium/standalone-firefox:147.0-20260202
         volumes:
           - ${{ github.workspace }}:/home/production/cxgn/sgn
           - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
+        env:
+          SE_NODE_MAX_SESSIONS: 4
         options: --health-cmd="curl --silent --head http://localhost:4444 || exit 1"
 
     steps:

--- a/t/lib/SGN/Test/WWW/WebDriver.pm
+++ b/t/lib/SGN/Test/WWW/WebDriver.pm
@@ -69,7 +69,11 @@ has 'host' => ( is => 'rw',
 
 has 'driver' => ( is => 'rw',
 		  isa => 'Selenium::Remote::Driver',
-		  default => sub { Selenium::Remote::Driver->new('base_url' => $ENV{SGN_TEST_SERVER}, 'remote_server_addr' => $ENV{SGN_REMOTE_SERVER_ADDR} || 'localhost') },
+		  default => sub {
+		  my $driver = Selenium::Remote::Driver->new('base_url' => $ENV{SGN_TEST_SERVER}, 'remote_server_addr' => $ENV{SGN_REMOTE_SERVER_ADDR} || 'localhost');
+		  $driver->commands->{_cmds}->{uploadFile}->{url} = 'session/:sessionId/se/file';
+		  return $driver;
+        },
     );
 
 has 'user_data' => ( is => 'rw',

--- a/t/selenium2/01_list/list_groups.t
+++ b/t/selenium2/01_list/list_groups.t
@@ -8,16 +8,16 @@ use SGN::Test::WWW::WebDriver;
 use Selenium::Firefox;
 use Selenium::Firefox::Profile;
 
-my $profile = Selenium::Firefox::Profile->new;
-$profile->set_preference( 'browser.download.folderList', 2 ); # Use custom download folder
-$profile->set_preference( 'browser.download.dir', '/tmp/download.txt' );
-$profile->set_preference( 'browser.download.manager.showWhenStarting', 0 );
-$profile->set_preference( 'browser.helperApps.neverAsk.saveToDisk', 'application/octet-stream,text/csv,application/zip,text/plain' );
+# my $profile = Selenium::Firefox::Profile->new;
+# $profile->set_preference( 'browser.download.folderList', 2 ); # Use custom download folder
+# $profile->set_preference( 'browser.download.dir', '/tmp/download.txt' );
+# $profile->set_preference( 'browser.download.manager.showWhenStarting', 0 );
+# $profile->set_preference( 'browser.helperApps.neverAsk.saveToDisk', 'application/octet-stream,text/csv,application/zip,text/plain' );
 
-my $driver = Selenium::Remote::Driver->new(firefox_profile => $profile, base_url => $ENV{SGN_TEST_SERVER}, remote_server_addr => $ENV{SGN_REMOTE_SERVER_ADDR} || 'localhost');
+#my $driver = Selenium::Remote::Driver->new(firefox_profile => $profile, base_url => $ENV{SGN_TEST_SERVER}, remote_server_addr => $ENV{SGN_REMOTE_SERVER_ADDR} || 'localhost');
 
 my $d = SGN::Test::WWW::WebDriver->new();
-$d->driver($driver);
+#$d->driver($driver);
 
 $d->while_logged_in_as("submitter", sub {
     # sleep(1);

--- a/t/selenium2/01_list/transform.t
+++ b/t/selenium2/01_list/transform.t
@@ -52,6 +52,8 @@ $d->while_logged_in_as('submitter', sub {
 
     print "Delete test list...\n";
 
+    sleep(1);
+
     my $delete_link = $d->find_element_ok("delete_list_new_test_list_transform", "id", "find delete test list button");
 
     $delete_link->click() if $delete_link;


### PR DESCRIPTION
Draft PR for testing.

**A summary of the issue from https://github.com/BFF-AFIRMS/breedbase_dockerfile/pull/7:**

The Selenium::Remote::Driver is [not compatible with v4](https://github.com/teodesian/Selenium-Remote-Driver?tab=readme-ov-file#warning) and the developer strongly warns against it. So we are still working with v3 selenium for now. Some initial testing suggests that it would be possible to migrate to v4, but I'd estimate that could be a week or so of dedicated work. It's also unclear how much of the existing tests would need to be rewritten, and what merge conflicts that would incur.