### PR TITLE
CI: Use new bffafirms/breedbase image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,119 +14,147 @@ jobs:
       - name: check group id
         run: echo "GROUP_ID=$(id -g)"
 
+
   test_breedbase:
     runs-on: ubuntu-latest
-    container:
-      image: bffafirms/breedbase:latest
-      env:
-        SYSTEM:                   GITACTION
-        USER_GROUP_ID:            1001:1001
-        MODE:                     TESTING
-        HOME:                     /home/sgn
-        DOMAIN_NAME:              localhost
-        PSQL_PAGER:               cat
-        HISTTIMEFORMAT:           "%Y-%m-%d %T "
-        SGN_TEST_SERVER:          http://test_breedbase:3010
-        SGN_REMOTE_SERVER_ADDR:   selenium
-        DBIC_TRACE:               0
-        # Database credentials
-        PGHOST:                   breedbase_db
-        PGDATABASE:               breedbase
-        PGUSER:                   postgres
-        PGPASSWORD:               postgres
-        WEB_USR_PASSWORD:         postgres
-        ADMIN_PASSWORD:           password
-      volumes:
-        - ${{ github.workspace }}:/home/production/cxgn/sgn
-        - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
-      options: --network-alias test_breedbase
-
-    services:
-      breedbase_db:
-        image: postgres:12.9
-        env:
-          POSTGRES_PASSWORD: postgres
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      selenium:
-        image: selenium/standalone-firefox:3.141.59
-        volumes:
-          - ${{ github.workspace }}:/home/production/cxgn/sgn
-          - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
-        options: --health-cmd="curl --silent --head http://localhost:4444 || exit 1"
-
-      keycloak_db:
-        image: postgres:13.0
-        env:
-          POSTGRES_DB: keycloak
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      keycloak:
-        image: bffafirms/keycloak:26.5.1-0-breedbase-testing
-        env:
-          KC_DB_USERNAME:              postgres
-          KC_DB_PASSWORD:              postgres
-          KC_BOOTSTRAP_ADMIN_PASSWORD: password
-
     steps:
-      - name: Checkout sgn
-        uses: actions/checkout@v5
-    
-      - name: Run unit tests
-        run: prove --recurse t/unit 2>/dev/null
+      - name: Checkout breedbase_dockerfile
+        uses: actions/checkout@v6
+        with:
+          name: bff-afirms/breedbase_dockerfile 
+          ref: bff-afirms
+          submodules: recursive
       
-      - name: Load/dump fixture database and build node modules
+      - name: Cleanup breedbase_dockerfile
         run: |
-          echo "--version" > ~/.proverc
-          perl t/test_fixture.pl --dumpupdatedfixture
-          rm ~/.proverc
-        # work around run_all_patches.pl "what the heck - no TTY??" error
-        # https://github.com/actions/runner/issues/241#issuecomment-842566950
-        shell: 'script --flush --quiet --return --command "bash --noprofile --norc -eo pipefail {0}"'
+          ls -l
+          ls -l breedbase_dockerfile
+          rm -rf breedbase_dockerfile/cxgn/sgn
 
-      - name: Run unit_fixture tests
-        # need entrypoint.sh to start slurm
-        # --nopatch to skip running fixture and db patches (already done in previous step)
-        run: /entrypoint.sh --nopatch t/unit_fixture 2>/dev/null
+      - name: Checkout sgn
+        uses: actions/checkout@v6
+        path: 'breedbase_dockerfile/cxgn/sgn'
+      
+      - name: Path Checkpoint
+        run: |
+          ls -l 
+          ls -l breedbase_dockerfile
+          ls -l breedbase_dockerfile/cxgn
+          ls -l breedbase_dockerfile/cxgn/sgn
 
-      - name: Run unit_mech tests
-        run: /entrypoint.sh --nopatch t/unit_mech
+  # test_breedbase:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: bffafirms/breedbase:latest
+  #     env:
+  #       SYSTEM:                   GITACTION
+  #       USER_GROUP_ID:            1001:1001
+  #       MODE:                     TESTING
+  #       HOME:                     /home/sgn
+  #       DOMAIN_NAME:              localhost
+  #       PSQL_PAGER:               cat
+  #       HISTTIMEFORMAT:           "%Y-%m-%d %T "
+  #       SGN_TEST_SERVER:          http://test_breedbase:3010
+  #       SGN_REMOTE_SERVER_ADDR:   selenium
+  #       DBIC_TRACE:               0
+  #       # Database credentials
+  #       PGHOST:                   breedbase_db
+  #       PGDATABASE:               breedbase
+  #       PGUSER:                   postgres
+  #       PGPASSWORD:               postgres
+  #       WEB_USR_PASSWORD:         postgres
+  #       ADMIN_PASSWORD:           password
+  #     volumes:
+  #       - ${{ github.workspace }}:/home/production/cxgn/sgn
+  #       - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
+  #     options: --network-alias test_breedbase
 
-      # selenium tests for a moment as separate folders - will change once full solgs are ready 
-      # but anyway, it will is still fully functional for tests purpose
-      - name: Run selenium tests 01_list
-        run: /entrypoint.sh --nopatch t/selenium2/01_list 2>/dev/null
+  #   services:
+  #     breedbase_db:
+  #       image: postgres:12.9
+  #       env:
+  #         POSTGRES_PASSWORD: postgres
+  #       # Set health checks to wait until postgres has started
+  #       options: >-
+  #         --health-cmd pg_isready
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
 
-      - name: Run selenium tests 02_trial
-        run: /entrypoint.sh --nopatch t/selenium2/02_trial 2>/dev/null
+  #     selenium:
+  #       image: selenium/standalone-firefox:3.141.59
+  #       volumes:
+  #         - ${{ github.workspace }}:/home/production/cxgn/sgn
+  #         - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
+  #       options: --health-cmd="curl --silent --head http://localhost:4444 || exit 1"
 
-      - name: Run selenium tests dataset
-        run: /entrypoint.sh --nopatch t/selenium2/03_dataset 2>/dev/null
+  #     keycloak_db:
+  #       image: postgres:13.0
+  #       env:
+  #         POSTGRES_DB: keycloak
+  #         POSTGRES_PASSWORD: postgres
+  #       options: >-
+  #         --health-cmd pg_isready
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
 
-      - name: Run selenium tests authenticate
-        run: /entrypoint.sh --nopatch t/selenium2/authenticate 2>/dev/null
+  #     keycloak:
+  #       image: bffafirms/keycloak:26.5.1-0-breedbase-testing
+  #       env:
+  #         KC_DB_USERNAME:              postgres
+  #         KC_DB_PASSWORD:              postgres
+  #         KC_BOOTSTRAP_ADMIN_PASSWORD: password
 
-      - name: Run selenium tests breeders
-        run: /entrypoint.sh --nopatch t/selenium2/breeders 2>/dev/null
+  #   steps:
+  #     - name: Checkout sgn
+  #       uses: actions/checkout@v5
+    
+  #     - name: Run unit tests
+  #       run: prove --recurse t/unit 2>/dev/null
+      
+  #     - name: Load/dump fixture database and build node modules
+  #       run: |
+  #         echo "--version" > ~/.proverc
+  #         perl t/test_fixture.pl --dumpupdatedfixture
+  #         rm ~/.proverc
+  #       # work around run_all_patches.pl "what the heck - no TTY??" error
+  #       # https://github.com/actions/runner/issues/241#issuecomment-842566950
+  #       shell: 'script --flush --quiet --return --command "bash --noprofile --norc -eo pipefail {0}"'
 
-      - name: Run selenium tests onto
-        run: /entrypoint.sh --nopatch t/selenium2/onto 2>/dev/null
+  #     - name: Run unit_fixture tests
+  #       # need entrypoint.sh to start slurm
+  #       # --nopatch to skip running fixture and db patches (already done in previous step)
+  #       run: /entrypoint.sh --nopatch t/unit_fixture 2>/dev/null
 
-      - name: Run selenium tests search
-        run: /entrypoint.sh --nopatch t/selenium2/search 2>/dev/null
+  #     - name: Run unit_mech tests
+  #       run: /entrypoint.sh --nopatch t/unit_mech
 
-      - name: Run selenium tests stock
-        run: /entrypoint.sh --nopatch t/selenium2/stock 2>/dev/null
+  #     # selenium tests for a moment as separate folders - will change once full solgs are ready 
+  #     # but anyway, it will is still fully functional for tests purpose
+  #     - name: Run selenium tests 01_list
+  #       run: /entrypoint.sh --nopatch t/selenium2/01_list 2>/dev/null
 
-      - name: Run selenium tests tools
-        run: /entrypoint.sh --nopatch t/selenium2/tools 2>/dev/null
+  #     - name: Run selenium tests 02_trial
+  #       run: /entrypoint.sh --nopatch t/selenium2/02_trial 2>/dev/null
+
+  #     - name: Run selenium tests dataset
+  #       run: /entrypoint.sh --nopatch t/selenium2/03_dataset 2>/dev/null
+
+  #     - name: Run selenium tests authenticate
+  #       run: /entrypoint.sh --nopatch t/selenium2/authenticate 2>/dev/null
+
+  #     - name: Run selenium tests breeders
+  #       run: /entrypoint.sh --nopatch t/selenium2/breeders 2>/dev/null
+
+  #     - name: Run selenium tests onto
+  #       run: /entrypoint.sh --nopatch t/selenium2/onto 2>/dev/null
+
+  #     - name: Run selenium tests search
+  #       run: /entrypoint.sh --nopatch t/selenium2/search 2>/dev/null
+
+  #     - name: Run selenium tests stock
+  #       run: /entrypoint.sh --nopatch t/selenium2/stock 2>/dev/null
+
+  #     - name: Run selenium tests tools
+  #       run: /entrypoint.sh --nopatch t/selenium2/tools 2>/dev/null

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,25 @@ jobs:
   test_breedbase:
     runs-on: ubuntu-latest
     steps:
+
+      # -----------------------------------------------------------------------
+      # Setup
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # when set to "true" but frees about 6 GB
+          tool-cache: true
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: false
+          large-packages: false
+          swap-storage: false
+
       - name: Checkout breedbase_dockerfile
         uses: actions/checkout@v6
         with:
@@ -20,135 +39,85 @@ jobs:
           submodules: recursive
       
       - name: Cleanup breedbase_dockerfile
-        run: |
-          ls -l
-          ls -l cxgn
-          rm -rf cxgn/sgn
+        run: rm -rf cxgn/sgn
 
       - name: Checkout sgn
         uses: actions/checkout@v6
         with:
           path: 'cxgn/sgn'
-      
-      - name: Path Checkpoint
+
+      - name: Setup
+        run: ./setup
+
+      - name: Build supporting images
+        run: docker compose -f compose.testing.yml build --no-cache
+
+      # -----------------------------------------------------------------------
+      # Testing
+
+      # use -s flag to show stderr
+      - name: Run quick setup
         run: |
-          ls -l 
-          ls -l cxgn
-          ls -l cxgn/sgn
+          ./run_test -s t/unit/CXGN/String
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  # test_breedbase:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: bffafirms/breedbase:latest
-  #     env:
-  #       SYSTEM:                   GITACTION
-  #       USER_GROUP_ID:            1001:1001
-  #       MODE:                     TESTING
-  #       HOME:                     /home/sgn
-  #       DOMAIN_NAME:              localhost
-  #       PSQL_PAGER:               cat
-  #       HISTTIMEFORMAT:           "%Y-%m-%d %T "
-  #       SGN_TEST_SERVER:          http://test_breedbase:3010
-  #       SGN_REMOTE_SERVER_ADDR:   selenium
-  #       DBIC_TRACE:               0
-  #       # Database credentials
-  #       PGHOST:                   breedbase_db
-  #       PGDATABASE:               breedbase
-  #       PGUSER:                   postgres
-  #       PGPASSWORD:               postgres
-  #       WEB_USR_PASSWORD:         postgres
-  #       ADMIN_PASSWORD:           password
-  #     volumes:
-  #       - ${{ github.workspace }}:/home/production/cxgn/sgn
-  #       - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
-  #     options: --network-alias test_breedbase
+      - name: Run unit tests
+        run: |
+          ./run_test t/unit
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #   services:
-  #     breedbase_db:
-  #       image: postgres:12.9
-  #       env:
-  #         POSTGRES_PASSWORD: postgres
-  #       # Set health checks to wait until postgres has started
-  #       options: >-
-  #         --health-cmd pg_isready
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
+      - name: Run fixture tests
+        run: |
+          ./run_test t/unit_fixture
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #     selenium:
-  #       image: selenium/standalone-firefox:3.141.59
-  #       volumes:
-  #         - ${{ github.workspace }}:/home/production/cxgn/sgn
-  #         - ${{ github.workspace }}:/home/vagrant/cxgn/sgn
-  #       options: --health-cmd="curl --silent --head http://localhost:4444 || exit 1"
+      - name: Run mech tests
+        run: |
+          ./run_test t/unit_mech
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #     keycloak_db:
-  #       image: postgres:13.0
-  #       env:
-  #         POSTGRES_DB: keycloak
-  #         POSTGRES_PASSWORD: postgres
-  #       options: >-
-  #         --health-cmd pg_isready
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
+      # Run all selenium tests individually to avoid solgs for now
+      - name: Run selenium tests lists
+        run: |
+          ./run_test t/selenium2/01_list
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #     keycloak:
-  #       image: bffafirms/keycloak:26.5.1-0-breedbase-testing
-  #       env:
-  #         KC_DB_USERNAME:              postgres
-  #         KC_DB_PASSWORD:              postgres
-  #         KC_BOOTSTRAP_ADMIN_PASSWORD: password
+      - name: Run selenium tests trial
+        run: |
+          ./run_test t/selenium2/02_trial
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #   steps:
-  #     - name: Checkout sgn
-  #       uses: actions/checkout@v5
-    
-  #     - name: Run unit tests
-  #       run: prove --recurse t/unit 2>/dev/null
-      
-  #     - name: Load/dump fixture database and build node modules
-  #       run: |
-  #         echo "--version" > ~/.proverc
-  #         perl t/test_fixture.pl --dumpupdatedfixture
-  #         rm ~/.proverc
-  #       # work around run_all_patches.pl "what the heck - no TTY??" error
-  #       # https://github.com/actions/runner/issues/241#issuecomment-842566950
-  #       shell: 'script --flush --quiet --return --command "bash --noprofile --norc -eo pipefail {0}"'
+      - name: Run selenium tests dataset
+        run: |
+          ./run_test t/selenium2/03_dataset
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #     - name: Run unit_fixture tests
-  #       # need entrypoint.sh to start slurm
-  #       # --nopatch to skip running fixture and db patches (already done in previous step)
-  #       run: /entrypoint.sh --nopatch t/unit_fixture 2>/dev/null
+      - name: Run selenium tests authenticate
+        run: |
+          ./run_test t/selenium2/authenticate
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #     - name: Run unit_mech tests
-  #       run: /entrypoint.sh --nopatch t/unit_mech
+      - name: Run selenium tests breeders
+        run: |
+          ./run_test t/selenium2/breeders
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #     # selenium tests for a moment as separate folders - will change once full solgs are ready 
-  #     # but anyway, it will is still fully functional for tests purpose
-  #     - name: Run selenium tests 01_list
-  #       run: /entrypoint.sh --nopatch t/selenium2/01_list 2>/dev/null
+      - name: Run selenium tests onto
+        run: |
+          ./run_test t/selenium2/onto
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #     - name: Run selenium tests 02_trial
-  #       run: /entrypoint.sh --nopatch t/selenium2/02_trial 2>/dev/null
+      - name: Run selenium tests search
+        run: |
+          ./run_test t/selenium2/search
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #     - name: Run selenium tests dataset
-  #       run: /entrypoint.sh --nopatch t/selenium2/03_dataset 2>/dev/null
+      - name: Run selenium tests stock
+        run: |
+          ./run_test t/selenium2/stock
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')
 
-  #     - name: Run selenium tests authenticate
-  #       run: /entrypoint.sh --nopatch t/selenium2/authenticate 2>/dev/null
-
-  #     - name: Run selenium tests breeders
-  #       run: /entrypoint.sh --nopatch t/selenium2/breeders 2>/dev/null
-
-  #     - name: Run selenium tests onto
-  #       run: /entrypoint.sh --nopatch t/selenium2/onto 2>/dev/null
-
-  #     - name: Run selenium tests search
-  #       run: /entrypoint.sh --nopatch t/selenium2/search 2>/dev/null
-
-  #     - name: Run selenium tests stock
-  #       run: /entrypoint.sh --nopatch t/selenium2/stock 2>/dev/null
-
-  #     - name: Run selenium tests tools
-  #       run: /entrypoint.sh --nopatch t/selenium2/tools 2>/dev/null
+      - name: Run selenium tests tools
+        run: |
+          ./run_test t/selenium2/tools
+          exit $(docker inspect testing-breedbase-1 --format='{{.State.ExitCode}}')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       image: bffafirms/breedbase:latest
       env:
         SYSTEM:                   GITACTION
-        USER_GROUP_ID:            1001:121
+        USER_GROUP_ID:            1001:1001
         MODE:                     TESTING
         HOME:                     /home/sgn
         DOMAIN_NAME:              localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,6 @@ on:
       - '**.md'
 
 jobs:
-  check_user_id:
-    runs-on: ubuntu-latest
-    steps:
-      - name: check user id
-        run: echo "USER_ID=$(id -u)"
-
-      - name: check group id
-        run: echo "GROUP_ID=$(id -g)"
-
 
   test_breedbase:
     runs-on: ubuntu-latest
@@ -31,20 +22,19 @@ jobs:
       - name: Cleanup breedbase_dockerfile
         run: |
           ls -l
-          ls -l breedbase_dockerfile
-          rm -rf breedbase_dockerfile/cxgn/sgn
+          ls -l cxgn
+          rm -rf cxgn/sgn
 
       - name: Checkout sgn
         uses: actions/checkout@v6
         with:
-          path: 'breedbase_dockerfile/cxgn/sgn'
+          path: 'cxgn/sgn'
       
       - name: Path Checkpoint
         run: |
           ls -l 
-          ls -l breedbase_dockerfile
-          ls -l breedbase_dockerfile/cxgn
-          ls -l breedbase_dockerfile/cxgn/sgn
+          ls -l cxgn
+          ls -l cxgn/sgn
 
   # test_breedbase:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,6 @@
+# Re-usable workflow to run tests
+name: Test
+
 on:
   pull_request:
     paths-ignore:
@@ -33,7 +36,8 @@ jobs:
 
       - name: Checkout sgn
         uses: actions/checkout@v6
-        path: 'breedbase_dockerfile/cxgn/sgn'
+        with:
+          path: 'breedbase_dockerfile/cxgn/sgn'
       
       - name: Path Checkpoint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ on:
 jobs:
   check_user_id:
     runs-on: ubuntu-latest
-  steps:
-    - name: check user id
-      run: echo "USER_ID=$(id -u)"
+    steps:
+      - name: check user id
+        run: echo "USER_ID=$(id -u)"
 
-    - name: check group id
-      run: echo "GROUP_ID=$(id -g)"
+      - name: check group id
+        run: echo "GROUP_ID=$(id -g)"
 
   test_breedbase:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout breedbase_dockerfile
         uses: actions/checkout@v6
         with:
-          name: bff-afirms/breedbase_dockerfile 
+          repository: bff-afirms/breedbase_dockerfile
           ref: bff-afirms
           submodules: recursive
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,17 +5,37 @@ on:
       - '**.md'
 
 jobs:
+  check_user_id:
+    runs-on: ubuntu-latest
+  steps:
+    - name: check user id
+      run: echo "USER_ID=$(id -u)"
+
+    - name: check group id
+      run: echo "GROUP_ID=$(id -g)"
+
   test_breedbase:
     runs-on: ubuntu-latest
     container:
-      image: breedbase/breedbase:latest
+      image: bffafirms/breedbase:latest
       env:
-        HOME: /root
-        MODE: 'TESTING'
-        SYSTEM: 'GITACTION'
-        PGPASSWORD: postgres
-        SGN_TEST_SERVER: http://test_breedbase:3010
-        SGN_REMOTE_SERVER_ADDR: selenium
+        SYSTEM:                   GITACTION
+        USER_GROUP_ID:            1001:121
+        MODE:                     TESTING
+        HOME:                     /home/sgn
+        DOMAIN_NAME:              localhost
+        PSQL_PAGER:               cat
+        HISTTIMEFORMAT:           "%Y-%m-%d %T "
+        SGN_TEST_SERVER:          http://test_breedbase:3010
+        SGN_REMOTE_SERVER_ADDR:   selenium
+        DBIC_TRACE:               0
+        # Database credentials
+        PGHOST:                   breedbase_db
+        PGDATABASE:               breedbase
+        PGUSER:                   postgres
+        PGPASSWORD:               postgres
+        WEB_USR_PASSWORD:         postgres
+        ADMIN_PASSWORD:           password
       volumes:
         - ${{ github.workspace }}:/home/production/cxgn/sgn
         - ${{ github.workspace }}:/home/vagrant/cxgn/sgn


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR changes the Github Actions continuous integration from using the image `breedbase/breedbase:latest` to our new image `bffafirms/breedbase:latest`. A summary of the image changes can be found in https://github.com/BFF-AFIRMS/breedbase_dockerfile/pull/7.

We pull the [BFF-AFIRMS/breedbase_dockerfile](https://github.com/BFF-AFIRMS/breedbase_dockerfile) repository, remove the `sgn` submodule within that repo, and replace it with the `sgn` changes coming in from the new commit. We  then use a `test.yml` CI workflow that is almost identical to the one in  [BFF-AFIRMS/breedbase_dockerfile](https://github.com/BFF-AFIRMS/breedbase_dockerfile). This allows us to have 1:1 consistency in CI tests across different repositories.

Simply switching out the image definition in old sgn workflow did not work because our new image is intimately tied to specialized functionality provided by docker compose. Specifically, the ability to do a two-stage entrypoint with the `post_start` config. Initial setup functions are run by the `root` user in the `post_start` phase, after which the container is run as a non-root user. As far as I know, Github Actions `container` config does not allow using these docker compose options.

There is also the added complexity that [BFF-AFIRMS/breedbase_dockerfile](https://github.com/BFF-AFIRMS/breedbase_dockerfile) and [BFF-AFIRMS/sgn](https://github.com/bff-afirms/sgn) have quite different `test.yml` workflow files. The underyling tests are the same, but the commands used to run them are significant different. Which means maintaining these two different workflows would have been considerable extra work.

<!-- If there are relevant issues, link them here: -->

- Resolves #15


Merge Style <!-- How should it be merged -->
---------------------------------------------------------------------------------------

Please use `Squash and Merge`, as the individual commits are not valuable, and they are all internal (not from an upstream we want to sync). But keep the individual commits documentation in the extended description of the commit message.

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
