### PR TITLE
tests: Remove sleeps from selenium2/tools tests

### DIFF
--- a/js/source/legacy/CXGN/Blast.js
+++ b/js/source/legacy/CXGN/Blast.js
@@ -208,7 +208,7 @@ function finish_blast(jobid, seq_count) {
 }
 
 function disable_ui() { 
-  jQuery('#myModal').modal({
+  jQuery('#blast_working_modal').modal({
     show: true,
     keyboard: false,
     backdrop: 'static'
@@ -217,7 +217,7 @@ function disable_ui() {
 }
 
 function enable_ui() { 
-  jQuery('#myModal').modal('hide');
+  jQuery('#blast_working_modal').modal('hide');
     // jQuery('#working').dialog("close");
     clear_status();
 }

--- a/mason/tools/blast/index.mas
+++ b/mason/tools/blast/index.mas
@@ -202,7 +202,7 @@ The default word_size for blastn is 11 and for protein-based blast programs it i
 
 <div id="jobid" style="display:none;"></div>
 
-<div class="modal fade" id="myModal" role="dialog">
+<div class="modal fade" id="blast_working_modal" role="dialog">
   <div class="modal-dialog modal-sm">
 
     <!-- Modal content-->

--- a/t/lib/SGN/Test/WWW/WebDriver.pm
+++ b/t/lib/SGN/Test/WWW/WebDriver.pm
@@ -61,16 +61,32 @@ use Try::Tiny;
 use Test::More;
 use File::Spec::Functions;
 use Selenium::Remote::Driver;
+use Selenium::Waiter qw(wait_until);
 
 has 'host' => ( is => 'rw',
 	      isa => 'Str',
 		default => sub { $ENV{SGN_TEST_SERVER} },
     );
 
+# Configurable implicit wait
+has 'implicit_wait' => ( is => 'rw', default => 45000 );
+
 has 'driver' => ( is => 'rw',
-		  isa => 'Selenium::Remote::Driver',
-		  default => sub { Selenium::Remote::Driver->new('base_url' => $ENV{SGN_TEST_SERVER}, 'remote_server_addr' => $ENV{SGN_REMOTE_SERVER_ADDR} || 'localhost') },
+          isa => 'Selenium::Remote::Driver',
+          lazy => 1,
+          builder => '_build_driver',
     );
+
+sub _build_driver {
+    my $self = shift;
+    my $driver = Selenium::Remote::Driver->new(
+        'base_url' => $ENV{SGN_TEST_SERVER},
+        'remote_server_addr' => $ENV{SGN_REMOTE_SERVER_ADDR} || 'localhost'
+    );
+    $driver->set_timeout('implicit', $self->implicit_wait);
+    $driver->set_timeout('page load', $self->implicit_wait);
+    return $driver;
+}
 
 has 'user_data' => ( is => 'rw',
 		     isa => 'Ref',
@@ -112,6 +128,8 @@ sub login {
     $password_field->send_keys($password);
     my $login_button = $d->find_element("submit_password", "id");
     $login_button->click();
+
+    sleep(2); # prevents an "error has occurred" alert
 }
 
 sub logout { 
@@ -208,6 +226,7 @@ sub download_linked_file {
 sub wait_for_working_dialog {
     my $self = shift;
     my $max = shift || 300;
+    my $id = shift || "working_modal";
 
     sleep(3);
 
@@ -215,13 +234,42 @@ sub wait_for_working_dialog {
     my $count = 0;
     print STDERR "... waiting for working dialog ...\n";
     while ( !$is_hidden && $count < $max ) {
-        my $wd = $self->find_element("working_modal", "id");
+        my $wd = $self->find_element($id, "id");
         $is_hidden = $wd->is_hidden();
         $count++;
         sleep(1);
     }
     print STDERR "... working dialog dismissed ...\n";
 }
+
+sub wait_for_spinner {
+    my $self = shift;
+    my ($name, $method) = @_;
+
+    wait_until {
+        print STDERR "Waiting for spinner to appear...\n";
+        $self->driver->find_element($name, $method)->is_displayed();
+    } and wait_until {
+        print STDERR "Waiting for spinner to disappear...\n";
+        $self->driver->find_element($name, $method)->is_hidden();
+    };
+}
+
+sub wait_for_alert_dismissed {
+    my $self = shift;
+    wait_until {
+        my $alert_text;
+
+        try {
+            $alert_text = $self->driver->get_alert_text();
+        } catch {
+            $alert_text = undef;
+        }
+
+        return !defined $alert_text;
+    }
+}
+
 
 1;
    

--- a/t/lib/SGN/Test/WWW/WebDriver.pm
+++ b/t/lib/SGN/Test/WWW/WebDriver.pm
@@ -129,7 +129,7 @@ sub login {
     my $login_button = $d->find_element("submit_password", "id");
     $login_button->click();
 
-    sleep(2); # prevents an "error has occurred" alert
+    sleep(2); # Determined empirically, prevents an "error has occurred" alert
 }
 
 sub logout { 
@@ -222,7 +222,23 @@ sub download_linked_file {
 
 }
 
+=item set_value_ok($self, $name, $method, $test_name, $value)
+Uses JavaScript to set the value of an input element more reliably
+than sending keys.
+=cut
+sub set_value_ok {
+    my ($self, $name, $method, $test_name, $value) = @_;
 
+    my $element = $self->find_element_ok($name, $method, $test_name);
+    $self->driver->execute_script("arguments[0].value = arguments[1];", $element, $value);
+    $self->driver->execute_script("arguments[0].dispatchEvent(new Event('change'));", $element);
+
+    return $element;
+}
+
+=item wait_for_working_dialog($self, $max, $id)
+Waits for a working dialog to disappear.  The default id is "working_modal".
+=cut
 sub wait_for_working_dialog {
     my $self = shift;
     my $max = shift || 300;
@@ -242,6 +258,9 @@ sub wait_for_working_dialog {
     print STDERR "... working dialog dismissed ...\n";
 }
 
+=item wait_for_spinner($self, $name, $method)
+Waits for an element to appear and disappear.
+=cut
 sub wait_for_spinner {
     my $self = shift;
     my ($name, $method) = @_;
@@ -255,6 +274,9 @@ sub wait_for_spinner {
     };
 }
 
+=item wait_for_alert_dismissed($self)
+Waits for an alert to disappear.
+=cut
 sub wait_for_alert_dismissed {
     my $self = shift;
     wait_until {

--- a/t/selenium2/tools/blast.t
+++ b/t/selenium2/tools/blast.t
@@ -9,7 +9,6 @@ use SGN::Test::WWW::WebDriver;
 my $t = SGN::Test::WWW::WebDriver->new();
 
 $t->get_ok('/tools/blast');
-sleep(5);
 
 #my $example = $t->find_element_ok('input_example', 'id', 'find input example link');
 #$example->click();
@@ -28,7 +27,7 @@ $input_box->send_keys($test_sequence);
 my $submit = $t->find_element_ok('submit_blast_button', 'id', 'find blast submit button');
 $submit->click();
 
-sleep(15);
+$t->wait_for_working_dialog(undef, "blast_working_modal");
 
 my $elem = $t->driver->find_element('SGN_output', 'id')->get_attribute('innerHTML');
 ok(lc($elem) =~ m/query[:\s]*1[\s]*aattcggcaccagtaaattttcccaaaggtttcaaaaatgaaaatttt/, "find aligned seq");

--- a/t/selenium2/tools/label_designer.t
+++ b/t/selenium2/tools/label_designer.t
@@ -13,25 +13,18 @@ my $f = SGN::Test::Fixture->new();
 my $t = SGN::Test::WWW::WebDriver->new();
 
 $t->while_logged_in_as("submitter", sub {
-    sleep(2);
-
     $t->get_ok('/tools/label_designer');
-
-    sleep(5);
 
     $t->driver->find_element("//button[\@title='Select a data source for the labels']")->click();
 
-    sleep(3);
-
     $t->driver->find_element("//li[\@data-original-index='5']")->click();
 
-    sleep(30);
+    $t->wait_for_working_dialog();
 
     $t->find_element_ok(
         '//select[@id="label_designer_data_level"]',
         "xpath",
         "select a data level")->click();
-    sleep(2);
 
     $t->find_element_ok(
         '//select[@id="label_designer_data_level"]/option[@value="plots"]',
@@ -42,165 +35,103 @@ $t->while_logged_in_as("submitter", sub {
 
     $t->driver->find_element("select_datasource_button","id", "click next")->click();
 
-    sleep(12);
-
     $t->find_element_ok("page_format", "id", "select a page format")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="page_format"]/option[contains(text(), "US Letter PDF")]',
         "xpath",
         "select a page format 'US Letter PDF'")->click();
-    sleep(1);
 
 
     $t->find_element_ok("label_format", "id", "select a label format")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="label_format"]/option[contains(text(), \'1" x 2 5/8"\')]',
         "xpath",
         "select a label format '1\" x 2 5/8\"'")->click();
-    sleep(1);
-
-    sleep(10);
 
     $t->driver->find_element("select_layout_button","id", "click next")->click();
 
-    sleep(3);
-
     $t->find_element_ok("d3-add-type-input", "id", "select a text element type")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="d3-add-type-input"]/option[contains(text(), "Text (PDF)")]',
         "xpath",
         "select a text element 'Text (PDF)'")->click();
-    sleep(1);
-
-    sleep(1);
 
     $t->driver->find_element("//select[\@id='d3-add-field-input']")->click();
 
-    sleep(3);
-
     $t->find_element_ok("d3-add-field-input", "id", "select a text element field")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="d3-add-field-input"]/option[contains(text(), "accession_name")]',
         "xpath",
         "select a text element 'accession_name'")->click();
 
-    sleep(1);
-
     my $size_input = $t->find_element_ok("d3-add-size-input", "id", "clear size field");
     $size_input->send_keys(KEYS->{'control'}, 'a');
     $size_input->send_keys(KEYS->{'backspace'});
-
-    sleep(1);
-
     $size_input->send_keys('64');
 
-    sleep(1);
-
     $t->find_element_ok("d3-add-font-input", "id", "select a text element font")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="d3-add-font-input"]/option[@value="Times-Bold"]',
         "xpath",
         "select a text font 'Times-Bold'")->click();
 
-    sleep(1);
-
     $t->find_element_ok("d3-add", "id", "add text")->click();
 
-    sleep(1);
-
     $t->find_element_ok("d3-add-type-input", "id", "select a QRcode element type")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="d3-add-type-input"]/option[contains(text(), "2D Barcode (QRCode)")]',
         "xpath",
         "select a type input as '2D Barcode (QRCode)'")->click();
 
-    sleep(1);
-
     $t->driver->find_element("//select[\@id='d3-add-field-input']")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="d3-add-field-input"]/option[text()="plot_name"]',
         "xpath",
         "select a field as 'plot_name'")->click();
 
-    sleep(1);
-
     $t->find_element_ok("d3-add-size-input", "id", "select a QRcode element size")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="d3-add-size-input"]/option[@value="6"]',
         "xpath",
         "select a text font size to '6'")->click();
 
-    sleep(1);
-
     $t->find_element_ok("d3-add", "id", "add QRcode")->click();
-
-    sleep(2);
 
     $t->find_element_ok("element1", "id", "click on new QRcode element")->click();
 
-    sleep(1);
-
     $t->find_element_ok("d3-add-type-input", "id", "select a  custom element type")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="d3-add-type-input"]/option[contains(text(), "Text (PDF)")]',
         "xpath",
         "select a text element 'Text (PDF)'")->click();
-    sleep(1);
 
     $t->find_element_ok("d3-custom-field", "id", "add custom element")->click();
 
-    sleep(1);
-
     $t->find_element_ok("d3-custom-input", "id", "add custom element text")->send_keys('Plot: ');
-
-    sleep(1);
 
     $t->driver->find_element("//select[\@id='d3-custom-add-field-input']")->click();
 
-    sleep(1);
-
     $t->find_element_ok("d3-custom-add-field-input", "id", "add custom element field")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="d3-custom-add-field-input"]/option[text()="plot_number"]',
         "xpath",
         "select field input as 'plot_number'")->click();
-    sleep(3);
 
     $t->find_element_ok("d3-custom-field-save", "id", "add custom element save")->click();
-
-    sleep(3);
 
     $size_input = $t->find_element_ok("d3-add-size-input", "id", "clear size field");
     $size_input->send_keys(KEYS->{'control'}, 'a');
     $size_input->send_keys(KEYS->{'backspace'});
     $size_input->send_keys('48');
 
-    sleep(3);
-
     $t->find_element_ok("d3-add-font-input", "id", "select a custom element font")->click();
-    sleep(3);
     $t->find_element_ok(
         '//select[@id="d3-add-font-input"]/option[@value="Times"]',
         "xpath",
         "select a text font size to '6'")->click();
-    sleep(3);
 
-
-    sleep(3);
 
     $t->find_element_ok("d3-add", "id", "add custom element")->click();
-
-    sleep(3);
 
     # If you look at gvncviewer output, this *should* work just fine. If you copy the steps in this test
     # and replicate them in your own browser, it *will* work just fine. But for some reason, this test fails.
@@ -212,16 +143,8 @@ $t->while_logged_in_as("submitter", sub {
 
     #save to list, reload page
     $t->find_element_ok("design_label_button", "id", "click on next")->click();
-
-    sleep(1);
-
     $t->find_element_ok("save_design_name", "id", "enter list name")->send_keys('test_label');
-
-    sleep(3);
-
     $t->find_element_ok("d3-save-button", "id", "save test label")->click();
-
-    sleep(3);
 
     $t->driver->accept_alert();
 
@@ -229,18 +152,10 @@ $t->while_logged_in_as("submitter", sub {
 
     $t->get_ok('/tools/label_designer');
 
-    sleep(3);
-
     $t->driver->find_element("//button[\@title='Select a data source for the labels']")->click();
-
-    sleep(3);
-
     $t->driver->find_element("//li[\@data-original-index='5']")->click();
 
-    sleep(12);
-
     $t->find_element_ok("label_designer_data_level","id", "select a data level")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="label_designer_data_level"]/option[@value="plots"]',
         "xpath",
@@ -250,30 +165,20 @@ $t->while_logged_in_as("submitter", sub {
 
     $t->driver->find_element("select_datasource_button","id", "click next")->click();
 
-    sleep(3);
-
     $t->find_element("//input[\@value='saved']")->click();
-
-    sleep(12);
 
     $t->driver->find_element("design_list_list_select","id", "click on saved options")->click();
 
-    sleep(6);
-
     $t->find_element_ok("design_list_list_select","id", "click on saved test label option")->click();
-    sleep(1);
     $t->find_element_ok(
         '//select[@id="design_list_list_select"]/option[text()="test_label"]',
         "xpath",
         "select a data level")->click();
 
-    sleep(12);
-
     #find loaded element
     # TODO : better test after load
     # $t->find_element_ok("element2", "id", "click on new custom element")->click();
     # sleep(1);
-    }
-);
+});
 
 done_testing();

--- a/t/selenium2/tools/treatment_designer.t
+++ b/t/selenium2/tools/treatment_designer.t
@@ -5,6 +5,7 @@ use SGN::Test::WWW::WebDriver;
 use SGN::Test::Fixture;
 use Selenium::Remote::WDKeys 'KEYS';
 use Selenium::Remote::WebElement;
+use Selenium::Waiter qw(wait_until);
 use Data::Dumper;
 
 use strict;
@@ -14,61 +15,33 @@ my $f = SGN::Test::Fixture->new();
 my $t = SGN::Test::WWW::WebDriver->new();
 
 $t->while_logged_in_as("curator", sub {
-    sleep(2);
-
     $t->get_ok('/treatments/design');
-
-    sleep(3);
 
     $t->find_element_ok('new_treatment_name', 'id', 'fill treatment name field')->send_keys("test treatment");
 
-    sleep(0.5);
-    
     $t->find_element_ok('new_treatment_definition', 'id', 'fill treatment definition field')->send_keys("A fake test treatment to see if the treatment designer can make new treatments during selenium tests.");
-
-    sleep(0.5);
 
     my $format_select = $t->find_element_ok('new_treatment_format_select', 'id', 'select categorical trait format')->click();
 
     $t->driver->find_element('//select[@id="new_treatment_format_select"]/option[@value="categorical"]', 'xpath')->click();
 
-    sleep(1);
-
     $t->find_element_ok('new_treatment_add_category', 'id', 'name first category')->send_keys("control");
-
     $t->find_element_ok('new_treatment_category_ordinal', 'id', 'assign first category as 0')->send_keys("0");
-
     $t->find_element_ok('new_treatment_add_category_btn', 'id', 'create first category')->click();
 
-    sleep(1);
-
     $t->find_element_ok('new_treatment_add_category', 'id', 'name second category')->send_keys("high");
-
     $t->find_element_ok('new_treatment_category_ordinal', 'id', 'assign second category as 1')->send_keys("1");
-
     $t->find_element_ok('new_treatment_add_category_btn', 'id', 'create second category')->click();
 
-    sleep(1);
-
     $t->find_element_ok('new_treatment_add_category', 'id', 'name bad category')->send_keys("testtesttest");
-
     $t->find_element_ok('new_treatment_category_ordinal', 'id', 'assign bad category as 33')->send_keys("33");
-
     $t->find_element_ok('new_treatment_add_category_btn', 'id', 'create bad category')->click();
-
-    sleep(1);
 
     $t->find_element_ok('new_treatment_remove_category_btn', 'id', 'delete bad category')->click();
 
-    sleep(1);
-
     $t->find_element_ok('new_treatment_submit_btn', 'id', 'submit new treatment')->click();
 
-    sleep(2);
-
-    $t->driver->accept_alert();
-
-    sleep(1);
+    wait_until { $t->driver->accept_alert(); }
 });
 
 done_testing();

--- a/t/selenium2/tools/trial_compare.t
+++ b/t/selenium2/tools/trial_compare.t
@@ -3,111 +3,97 @@ use strict;
 
 use lib 't/lib';
 
-use Test::More 'tests' => 24;
+use Test::More 'tests' => 26;
 use SGN::Test::WWW::WebDriver;
+
+use Selenium::Waiter qw(wait_until);
 
 my $d = SGN::Test::WWW::WebDriver->new();
 
 $d->while_logged_in_as('submitter', sub {
-
     $d->get_ok('/tools');  # something else than the index page, which has a dialog that messes up the test
-    sleep(2);
 
     # Create a new trail list for comparison test
-    my $lists = $d->find_element_ok('navbar_lists', 'id', 'find navbar list button');
+    my $lists = $d->find_element_ok("navbar_lists", "id", "find navbar list button");
     $lists->click();
-    sleep(2);
-    my $add_list_input = $d->find_element_ok('add_list_input', 'id', 'find add list input');
-    $add_list_input->send_keys('new_trial_list');
 
-    my $add_list_button = $d->find_element_ok('add_list_button', 'id', 'find add list button');
+    my $add_list_input = $d->find_element_ok("add_list_input", "id", "find add list input");
+    $add_list_input->send_keys("new_trial_list");
+
+    my $add_list_button = $d->find_element_ok("add_list_button", "id", "find add list button");
     $add_list_button->click();
 
     $d->find_element_ok(
          '//div[@id="private_list_data_table_filter"]//input[@type="search"]',
          "xpath",
-         "find search in table and find 'new_trial_list'")->send_keys('new_trial_list');
-    sleep(3);
+         "find search in table and find 'new_trial_list'")->send_keys("new_trial_list");
 
     $d->find_element_ok("view_list_new_trial_list", "id", "view new list test")->click();
-    sleep(3);
 
     $d->find_element_ok("updateListDescField", "id", "add trial test list description")->send_keys("new_trial_list_description");
-    sleep(1);
 
     $d->find_element_ok("updateListDescButton", "id", "find update List Desc Button")->click();
-    sleep(1);
-    $d->driver()->accept_alert();
-    sleep(1);
+    wait_until { $d->driver()->accept_alert(); };
+    $d->wait_for_alert_dismissed();
 
-
-    $d->find_element_ok("dialog_add_list_item", "id", "add trial test list")->send_keys("Kasese solgs trial\ntrial2 NaCRRI");
-
-    sleep(1);
+    my $textarea = $d->find_element_ok("dialog_add_list_item", "id", "add trial test list");
+    my $trials_list = "Kasese solgs trial\ntrial2 NaCRRI";
+    $textarea->send_keys($trials_list);
+    wait_until { $textarea->get_attribute("value") eq $trials_list; };
 
     $d->find_element_ok("dialog_add_list_item_button", "id", "find dialog_add_list_item_button test")->click();
-
-    sleep(3);
+    wait_until { 
+        my @rows = $d->driver->find_elements('//table[@id="list_item_dialog_datatable"]/tbody/tr', "xpath");
+        return scalar @rows == 2;
+    };
 
     $d->find_element_ok("type_select", "id", "find select of type list")->click();
-    sleep(1);
     $d->find_element_ok(
         '//select[@id="type_select"]/option[@name="trials"]',
         "xpath",
         "select 'trials' as type list")->click();
-    sleep(1);
 
     $d->find_element_ok("list_item_dialog_validate", "id", "find and click validate 'trails' type list")->click();
-    sleep(5);
+    wait_until { $d->accept_alert_ok("accept validation alert"); };
 
-    $d->driver()->accept_alert();
-    sleep(1);
+    $d->wait_for_working_dialog();
 
     $d->find_element_ok("close_list_item_dialog", "id", "find close list item dialog")->click();
 
-    sleep(1);
-
     $d->find_element_ok("close_list_dialog_button", "id", "find close dialog button")->click();
 
-    sleep(1);
-
     # Change page to trial comparison
-    $d->get_ok('/tools/trial/comparison/list');
+    $d->get_ok("/tools/trial/comparison/list");
 
-    sleep(10);
-
-    $d->find_element("trials_list_select", "id", "find trials select")->click();
-    sleep(1);
+    $d->find_element_ok("trials_list_select", "id", "find trials select")->click();
 
     $d->find_element_ok(
         '//select[@id="trials_list_select"]/option[contains(text(), "new_trial_list")]',
         "xpath",
         "select 'new_trial_list' as list")->click();
-    sleep(6);
+    
+    $d->wait_for_spinner("trials-loading-spinner", "id");
 
     $d->find_element_ok("unit_select", "id", "find select plot observation level")->click();
-    sleep(1);
 
     $d->find_element_ok(
         '//select[@id="unit_select"]/option[@value="plot"]',
         "xpath",
         "select plot observation level")->click();
-    sleep(20);
+    
+    $d->wait_for_spinner("trials-loading-spinner", "id");
 
     $d->find_element_ok("trait_select", "id", "find trait select");
-    sleep(1);
     $d->find_element_ok(
         '//select[@id="trait_select"]/option[contains(text(), "dry matter content percentage|CO_334:0000092")]',
         "xpath",
         "select 'new_trial_list' as list")->click();
-    sleep(4);
-
+    
     # Check trial names on axis of created plot
     my $plot_view = $d->find_element_ok(
         '//div[@id="tc-grid"]',
         'xpath',
         'find a content of plot')->get_attribute('innerHTML');
-    sleep(1);
 
     ok($plot_view =~ /trial2 NaCRRI/, "Verify if test_accession1 on pedigree panel");
     ok($plot_view =~ /Kasese solgs trial/, "Verify if 'Kasese solgs trial' on pedigree panel");

--- a/t/selenium2/tools/trial_compare.t
+++ b/t/selenium2/tools/trial_compare.t
@@ -36,10 +36,10 @@ $d->while_logged_in_as('submitter', sub {
     wait_until { $d->driver()->accept_alert(); };
     $d->wait_for_alert_dismissed();
 
-    my $textarea = $d->find_element_ok("dialog_add_list_item", "id", "add trial test list");
     my $trials_list = "Kasese solgs trial\ntrial2 NaCRRI";
-    $textarea->send_keys($trials_list);
-    wait_until { $textarea->get_attribute("value") eq $trials_list; };
+    $d->set_value_ok("dialog_add_list_item", "id", "add trial test list", $trials_list);
+
+    sleep(1); # Determined empirically; needed so the following button click will register
 
     $d->find_element_ok("dialog_add_list_item_button", "id", "find dialog_add_list_item_button test")->click();
     wait_until { 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR improves the speed and reliability of the selenium tests under `t/selenium2/tools/` by replacing arbitrary `sleep()` calls with proper explicit waits using `Selenium::Waiter` and new helper methods (`wait_for_working_dialog`, `wait_for_spinner`, `wait_for_alert_dismissed`).  

Key changes:
- Refactored `SGN::Test::WWW::WebDriver` to support configurable implicit wait timeouts and lazy driver construction.
- Added `wait_for_working_dialog` with configurable element ID parameter (used for BLAST modal).
- Added `wait_for_spinner` to wait for loading spinners to appear and then disappear.
- Added `wait_for_alert_dismissed` to wait until an alert is no longer present.
- Updated `t/selenium2/tools/blast.t`, `label_designer.t`, `treatment_designer.t`, and `trial_compare.t` to use these new methods, removing all fixed sleep statements.
- Fixed a minor naming issue in the BLAST modal (`myModal` → `blast_working_modal`) and updated the JS accordingly.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
