### PR TITLE
trial: fix linked seedlots breaking treatments for #37

### DIFF
--- a/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
+++ b/lib/SGN/Controller/AJAX/PhenotypesUpload.pm
@@ -391,7 +391,7 @@ sub _prep_upload {
                 });
                 my $child_stocks = $plot_obj->get_child_stocks_flat_list();
                 foreach my $child (@{$child_stocks}) {
-                    next if ($child->{type} eq "accession");
+                    next if ($child->{type} eq "accession") || ($child->{type} eq "seedlot");
                     push @plots, $child->{name};
                     foreach my $trait (@traits) {
                         $parsed_data{$child->{name}}->{$trait} = $parsed_data{$plot}->{$trait};


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixes an issue in which linking seedlots to a trial causes treatment uploads to break.

- Resolves #37

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
