### PR TITLE
trial: add seedlot to spatial layout download

### DIFF
--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -502,7 +502,10 @@ $trial_stock_type => undef
                                     </div>
 % }
                                     <div class="checkbox">
-                                        <label> <input type="checkbox" id="obs_unit_name" value="obsunit_name"> Observation Unit Name </label>
+                                        <label> <input type="checkbox" id="obs_unit_name" value="obsunit_name"> Plot Name </label>
+                                    </div>
+                                    <div class="checkbox">
+                                        <label> <input type="checkbox" id="seedlot_name" value="seedlot_name"> Seedlot Name </label>
                                     </div>
                                     <div class="checkbox">
                                         <label> <input type="checkbox" id="plot_id" value="plot_id"> Plot ID </label>
@@ -1501,6 +1504,7 @@ function _finish() {
   jQuery("#download_field_layout_button").click( function () {
     const includeAccessionName = jQuery('#accession_name').is(':checked');
     const includeObsUnitName = jQuery('#obs_unit_name').is(':checked');
+    const includeSeedlotName = jQuery('#seedlot_name').is(':checked');
     const includePlotId = jQuery('#plot_id').is(':checked');
     const includePlotNum = jQuery('#plot_num').is(':checked');
 
@@ -1538,8 +1542,12 @@ function _finish() {
         } else {
             cellVal = '';
         }
+
         if (includeObsUnitName && plot.observationUnitName) {
             cellVal += (cellVal ? '\n' : '') + plot.observationUnitName;
+        }
+        if (includeSeedlotName && plot.seedLotName) {
+            cellVal += (cellVal ? '\n' : '') + plot.seedLotName;
         }
         if (includePlotId && plot.observationUnitDbId) {
             cellVal += (cellVal ? '\n' : '') + plot.observationUnitDbId;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This pull request adds the ability to download the spatial layout of a trial or orchard using the seedlot in a plot.

- Resolves #42 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
