### PR TITLE
trait: use synonym instead of acronym where available

### DIFF
--- a/lib/SGN/Controller/solGS/Trait.pm
+++ b/lib/SGN/Controller/solGS/Trait.pm
@@ -16,7 +16,6 @@ use List::MoreUtils qw /uniq/;
 use Array::Utils qw(:all);
 use JSON;
 use SGN::Controller::solGS::Utils;
-use CXGN::Cvterm;
 
 
 BEGIN { extends 'Catalyst::Controller' }
@@ -278,25 +277,10 @@ sub traits_acronym_table {
     if (keys %$acronym_table)
     {
 	my $table = 'Acronym' . "\t" . 'Trait name' . "\n";
-	my $schema = $c->dbic_schema("Bio::Chado::Schema");
 
 	foreach (keys %$acronym_table)
 	{
-		my $trait_name = $acronym_table->{$_};
-		my $acronym = $_;
-
-		my $query = "select cvterm_id from cvterm where replace(name, '|', ' ') = ?";
-		my $cvterm_sth = $schema->storage->dbh->prepare($query);
-		$cvterm_sth->execute($trait_name);
-		my $cvterm_id = $cvterm_sth->fetchrow_array();
-		if ($cvterm_id){
-			my $cvterm = CXGN::Cvterm->new({ schema=>$schema, cvterm_id => $cvterm_id } );
-			my $synonym = $cvterm->get_single_synonym();
-			if ($synonym){
-				$acronym = $synonym;
-			}
-		}
-		$table .= $acronym . "\t" . $acronym_table->{$_} . "\n";
+	    $table .= $_ . "\t" . $acronym_table->{$_} . "\n";
 	}
 
 	$c->controller('solGS::Files')->traits_acronym_file($c, $pop_id);

--- a/lib/SGN/Controller/solGS/Trait.pm
+++ b/lib/SGN/Controller/solGS/Trait.pm
@@ -16,6 +16,7 @@ use List::MoreUtils qw /uniq/;
 use Array::Utils qw(:all);
 use JSON;
 use SGN::Controller::solGS::Utils;
+use CXGN::Cvterm;
 
 
 BEGIN { extends 'Catalyst::Controller' }
@@ -277,10 +278,18 @@ sub traits_acronym_table {
     if (keys %$acronym_table)
     {
 	my $table = 'Acronym' . "\t" . 'Trait name' . "\n";
+	my $schema = $c->dbic_schema("Bio::Chado::Schema");
 
 	foreach (keys %$acronym_table)
 	{
-	    $table .= $_ . "\t" . $acronym_table->{$_} . "\n";
+		my $trait_name = $acronym_table->{$_};
+		my $trait_rs = $schema->resultset("Cv::Cvterm")->find({ name => $trait_name });
+		my $cvterm = CXGN::Cvterm->new({ schema=>$schema, cvterm_id => $trait_rs->cvterm_id() } );
+		my $synonym = $cvterm->get_single_synonym();
+		if (! $synonym){
+			$synonym = $_;
+		}
+		$table .= $synonym . "\t" . $acronym_table->{$_} . "\n";
 	}
 
 	$c->controller('solGS::Files')->traits_acronym_file($c, $pop_id);

--- a/lib/SGN/Controller/solGS/Trait.pm
+++ b/lib/SGN/Controller/solGS/Trait.pm
@@ -283,13 +283,20 @@ sub traits_acronym_table {
 	foreach (keys %$acronym_table)
 	{
 		my $trait_name = $acronym_table->{$_};
-		my $trait_rs = $schema->resultset("Cv::Cvterm")->find({ name => $trait_name });
-		my $cvterm = CXGN::Cvterm->new({ schema=>$schema, cvterm_id => $trait_rs->cvterm_id() } );
-		my $synonym = $cvterm->get_single_synonym();
-		if (! $synonym){
-			$synonym = $_;
+		my $acronym = $_;
+
+		my $query = "select cvterm_id from cvterm where replace(name, '|', ' ') = ?";
+		my $cvterm_sth = $schema->storage->dbh->prepare($query);
+		$cvterm_sth->execute($trait_name);
+		my $cvterm_id = $cvterm_sth->fetchrow_array();
+		if ($cvterm_id){
+			my $cvterm = CXGN::Cvterm->new({ schema=>$schema, cvterm_id => $cvterm_id } );
+			my $synonym = $cvterm->get_single_synonym();
+			if ($synonym){
+				$acronym = $synonym;
+			}
 		}
-		$table .= $synonym . "\t" . $acronym_table->{$_} . "\n";
+		$table .= $acronym . "\t" . $acronym_table->{$_} . "\n";
 	}
 
 	$c->controller('solGS::Files')->traits_acronym_file($c, $pop_id);

--- a/lib/SGN/Controller/solGS/Utils.pm
+++ b/lib/SGN/Controller/solGS/Utils.pm
@@ -7,6 +7,9 @@ use File::Slurp qw /write_file read_file edit_file/;
 use JSON;
 use List::MoreUtils qw(first_index);
 
+our $c;
+use CatalystX::GlobalContext qw($c);
+
 sub convert_arrayref_to_hashref {
     my ($self, $array_ref) = @_;
 
@@ -150,6 +153,19 @@ sub top_10 {
 
 sub abbreviate_term {
     my ($self, $term) = @_;
+
+    my $schema = $c->dbic_schema("Bio::Chado::Schema");
+    my $query = "select cvterm_id from cvterm where replace(name, '|', ' ') = ?";
+    my $cvterm_sth = $schema->storage->dbh->prepare($query);
+    $cvterm_sth->execute($term);
+    my $cvterm_id = $cvterm_sth->fetchrow_array();
+    if ($cvterm_id){
+        my $cvterm = CXGN::Cvterm->new({ schema=>$schema, cvterm_id => $cvterm_id } );
+        my $synonym = $cvterm->get_single_synonym();
+        if ($synonym){
+            return $synonym;
+        }
+    }
 
     $term =~ s/\// /g;
     $term =~ s/-/_/g;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This pull request priorites the use of trait synonyms over acronyms.

- Resolves #50 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
