### PR TITLE
lib: explicit defined checks for  phenotype values to permit 0 

### DIFF
--- a/lib/CXGN/Trial/TrialLayoutDownload.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload.pm
@@ -438,7 +438,7 @@ sub _add_exact_performance_to_line {
 
     foreach my $trait (@$exact_trait_names){
         my $value = $exact_performance_hash->{$trait}->{$observationunit_name };
-        if($value || $value == 0) {
+        if(defined $value && length $value) {
             push @$line, $value
         } else {
             push @$line, '';

--- a/lib/CXGN/Trial/TrialLayoutDownload.pm
+++ b/lib/CXGN/Trial/TrialLayoutDownload.pm
@@ -438,7 +438,7 @@ sub _add_exact_performance_to_line {
 
     foreach my $trait (@$exact_trait_names){
         my $value = $exact_performance_hash->{$trait}->{$observationunit_name };
-        if($value) {
+        if($value || $value == 0) {
             push @$line, $value
         } else {
             push @$line, '';


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixes a bug in which phenotypes with a value of '0' are exported as the empty string in the database.

- Resolves #57

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
