### PR TITLE
db: add indexing patch to speed up phenotype downloads for #48, #49

### DIFF
--- a/db/00205.1/IndexNdExperiment.pm
+++ b/db/00205.1/IndexNdExperiment.pm
@@ -1,0 +1,64 @@
+#!/usr/bin/env perl
+
+=head1 NAME
+
+IndexNdExperiment.pm
+
+=head1 SYNOPSIS
+
+mx-run IndexNdExperiment [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+This patch:
+ - Adds indexes to assorted nd_experiment_* tables to speed up phenotype queries.
+
+=head1 AUTHOR
+
+Katherine Eaton
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2026 University of Alberta
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+package IndexNdExperiment;
+
+use Moose;
+use Bio::Chado::Schema;
+extends 'CXGN::Metadata::Dbpatch';
+
+has '+description' => ( default => <<'' );
+This patch adds indexes to assorted nd_experiment_* tables to speed up phenotype queries.
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    $self->dbh->do(<<EOSQL);
+create index nd_experiment_phenotype_idx1 on nd_experiment_phenotype (phenotype_id);
+create index nd_experiment_stock_idx1 on nd_experiment_stock (nd_experiment_id);
+create index nd_experiment_stock_idx2 on nd_experiment_stock (stock_id);
+create index nd_experiment_project_idx1 on nd_experiment_project (nd_experiment_id);
+create index nd_experiment_project_idx2 on nd_experiment_project (project_id);
+
+EOSQL
+
+    print "You're done!\n";
+}
+
+####
+1; #
+####

--- a/lib/CXGN/Stock/Seedlot.pm
+++ b/lib/CXGN/Stock/Seedlot.pm
@@ -501,7 +501,7 @@ sub list_seedlots {
             join => \@seedlot_search_joins,
             '+select'=>['project.name', 'project.project_id', 'subject.stock_id', 'subject.uniquename', 'subject.type_id', 'nd_geolocation.description', 'nd_geolocation.nd_geolocation_id'],
             '+as'=>['breeding_program_name', 'breeding_program_id', 'source_stock_id', 'source_uniquename', 'source_type_id', 'location', 'location_id'],
-            order_by => {-asc=>'project.name'},
+            order_by => {-asc=> [qw/project.name me.stock_id/] }
             #distinct => 1
         }
     );


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR speeds up phenotype downloads by adding a database patch to index assorted `nd_experiment_*` tables. More information on the origin of this problem can be found in Issue #49.

Initially, a BrAPI seedlot test was failing, because the order of seedlots output by the backend was not the order that the test was expecting. The function that outputs a list of seedlots in the database has an order by statement, which uses a column (project name) that is not unique to every seedlot. Because of this, adding new indexes to the tables involved in the joins (`nd_experiment_*` tables) caused the order to shift slightly. I remedied this by investigating what the original order was based on before the new indexes were added and it appears that the ordering was informally done by `project.name` + `stock.stock_id`. So I've expilcitly added ordering by the `stock_id` and now the seedlot order is the same as before, and tests pass!

<!-- If there are relevant issues, link them here: -->
- Resolves #48
- Resolves #49

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
