### PR TITLE
lib: use trait synonyms instead of acronyms

### DIFF
--- a/lib/CXGN/Project.pm
+++ b/lib/CXGN/Project.pm
@@ -3118,7 +3118,7 @@ sub get_traits_assayed {
     if ($stock_type) {
         # print STDERR " the stock type here: = $stock_type\n";
         my $stock_type_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema(), $stock_type, 'stock_type')->cvterm_id();
-        $q = "SELECT (((cvterm.name::text || '|'::text) || db.name::text) || ':'::text) || dbxref.accession::text AS trait, cvterm.cvterm_id, imaging_project.project_id, imaging_project.name, count(phenotype.value)
+        $q = "SELECT (((cvterm.name::text || '|'::text) || db.name::text) || ':'::text) || dbxref.accession::text AS trait, cvterm.cvterm_id, imaging_project.project_id, imaging_project.name, count(phenotype.value), COALESCE(synonyms_table.synonyms, '[]'::jsonb)
             FROM cvterm
             $cvtermprop_join
             JOIN dbxref ON (cvterm.dbxref_id = dbxref.dbxref_id)
@@ -3127,15 +3127,16 @@ sub get_traits_assayed {
             JOIN nd_experiment_phenotype USING(phenotype_id)
             JOIN nd_experiment_project USING(nd_experiment_id)
             JOIN nd_experiment_stock USING(nd_experiment_id)
+            LEFT JOIN (SELECT cvterm_id, jsonb_agg(synonym) as synonyms FROM cvtermsynonym GROUP BY cvterm_id) AS synonyms_table ON (cvterm.cvterm_id = synonyms_table.cvterm_id)
             LEFT JOIN phenome.nd_experiment_md_images AS nd_experiment_md_images USING(nd_experiment_id)
             LEFT JOIN phenome.project_md_image AS project_md_image ON (nd_experiment_md_images.image_id=project_md_image.image_id)
             LEFT JOIN project AS imaging_project ON (project_md_image.project_id=imaging_project.project_id)
             JOIN stock on (stock.stock_id = nd_experiment_stock.stock_id)
             WHERE stock.type_id=$stock_type_cvterm_id and nd_experiment_project.project_id=? $cvtermprop_where
-            GROUP BY trait, cvterm.cvterm_id, imaging_project.project_id, imaging_project.name
+            GROUP BY trait, cvterm.cvterm_id, imaging_project.project_id, imaging_project.name, synonyms_table.synonyms
             ORDER BY trait;";
     } else {
-        $q = "SELECT (((cvterm.name::text || '|'::text) || db.name::text) || ':'::text) || dbxref.accession::text AS trait, cvterm.cvterm_id, imaging_project.project_id, imaging_project.name, count(phenotype.value)
+        $q = "SELECT (((cvterm.name::text || '|'::text) || db.name::text) || ':'::text) || dbxref.accession::text AS trait, cvterm.cvterm_id, imaging_project.project_id, imaging_project.name, count(phenotype.value), COALESCE(synonyms_table.synonyms, '[]'::jsonb)
             FROM cvterm
             $cvtermprop_join
             JOIN dbxref ON (cvterm.dbxref_id = dbxref.dbxref_id)
@@ -3143,21 +3144,23 @@ sub get_traits_assayed {
             JOIN phenotype ON (cvterm.cvterm_id=phenotype.cvalue_id)
             JOIN nd_experiment_phenotype USING(phenotype_id)
             JOIN nd_experiment_project USING(nd_experiment_id)
+            LEFT JOIN (SELECT cvterm_id, jsonb_agg(synonym) as synonyms FROM cvtermsynonym GROUP BY cvterm_id) AS synonyms_table ON (cvterm.cvterm_id = synonyms_table.cvterm_id)
             LEFT JOIN phenome.nd_experiment_md_images AS nd_experiment_md_images USING(nd_experiment_id)
             LEFT JOIN phenome.project_md_image AS project_md_image ON (nd_experiment_md_images.image_id=project_md_image.image_id)
             LEFT JOIN project AS imaging_project ON (project_md_image.project_id=imaging_project.project_id)
             WHERE nd_experiment_project.project_id=? $cvtermprop_where
-            GROUP BY trait, cvterm.cvterm_id, imaging_project.project_id, imaging_project.name
+            GROUP BY trait, cvterm.cvterm_id, imaging_project.project_id, imaging_project.name, synonyms_table.synonyms
             ORDER BY trait;";
     }
 
     my $component_q = "SELECT COALESCE(
-            json_agg(json_build_object('cvterm_id', component_cvterm.cvterm_id, 'name', component_cvterm.name, 'definition', component_cvterm.definition, 'cv_name', cv.name, 'cv_type', cv_type.name, 'cv_type_cvterm_id', cv_type.cvterm_id))
+            json_agg(json_build_object('cvterm_id', component_cvterm.cvterm_id, 'name', component_cvterm.name, 'definition', component_cvterm.definition, 'cv_name', cv.name, 'cv_type', cv_type.name, 'cv_type_cvterm_id', cv_type.cvterm_id, 'synonyms', COALESCE(synonyms_table.synonyms, '[]'::jsonb)))
             FILTER (WHERE component_cvterm.cvterm_id IS NOT NULL), '[]'
         ) AS components
         FROM cvterm
         LEFT JOIN cvterm_relationship on (cvterm.cvterm_id = cvterm_relationship.object_id AND cvterm_relationship.type_id = ?)
         LEFT JOIN cvterm AS component_cvterm on (cvterm_relationship.subject_id = component_cvterm.cvterm_id)
+        LEFT JOIN (SELECT cvterm_id, jsonb_agg(synonym) as synonyms FROM cvtermsynonym GROUP BY cvterm_id) AS synonyms_table ON (component_cvterm.cvterm_id = synonyms_table.cvterm_id)
         LEFT JOIN cv on (component_cvterm.cv_id = cv.cv_id)
         LEFT JOIN cvprop on (cv.cv_id = cvprop.cv_id)
         LEFT JOIN cvterm AS cv_type on (cv_type.cvterm_id = cvprop.type_id)
@@ -3169,10 +3172,11 @@ sub get_traits_assayed {
     my $component_h = $dbh->prepare($component_q);
 
     $traits_assayed_h->execute($self->get_trial_id());
-    while (my ($trait_name, $trait_id, $imaging_project_id, $imaging_project_name, $count) = $traits_assayed_h->fetchrow_array()) {
+    while (my ($trait_name, $trait_id, $imaging_project_id, $imaging_project_name, $count, $synonyms_json) = $traits_assayed_h->fetchrow_array()) {
         $component_h->execute($contains_relationship_cvterm_id, $trait_id);
         my ($component_terms) = $component_h->fetchrow_array();
         $component_terms = decode_json $component_terms;
+        my $synonyms = decode_json $synonyms_json;
         if ($contains_composable_cv_type) {
             my $has_composable_cv_type = 0;
             foreach (@$component_terms) {
@@ -3181,11 +3185,11 @@ sub get_traits_assayed {
                 }
             }
             if ($has_composable_cv_type == 1) {
-                push @traits_assayed, [$trait_id, $trait_name, $component_terms, $count, $imaging_project_id, $imaging_project_name];
+                push @traits_assayed, [$trait_id, $trait_name, $component_terms, $count, $imaging_project_id, $imaging_project_name, $synonyms];
             }
         }
         else {
-            push @traits_assayed, [$trait_id, $trait_name, $component_terms, $count, $imaging_project_id, $imaging_project_name];
+            push @traits_assayed, [$trait_id, $trait_name, $component_terms, $count, $imaging_project_id, $imaging_project_name, $synonyms];
         }
     }
     return \@traits_assayed;

--- a/lib/CXGN/Project.pm
+++ b/lib/CXGN/Project.pm
@@ -3192,6 +3192,7 @@ sub get_traits_assayed {
             push @traits_assayed, [$trait_id, $trait_name, $component_terms, $count, $imaging_project_id, $imaging_project_name, $synonyms];
         }
     }
+
     return \@traits_assayed;
 }
 

--- a/lib/SGN/Controller/solGS/Trait.pm
+++ b/lib/SGN/Controller/solGS/Trait.pm
@@ -159,10 +159,10 @@ sub save_single_trial_traits {
 
     if (!-s $traits_file)
     {
-	my $trait_names = $c->controller('solGS::Utils')->get_clean_trial_trait_names($c, $pop_id);
+        my $trait_names = $c->controller('solGS::Utils')->get_clean_trial_trait_names($c, $pop_id);
 
-	$trait_names = join("\t", @$trait_names);
-	write_file($traits_file, {binmode => ':utf8'}, $trait_names);
+        $trait_names = join("\t", @$trait_names);
+        write_file($traits_file, {binmode => ':utf8'}, $trait_names);
     }
 
 }
@@ -178,11 +178,11 @@ sub get_all_traits {
 
     if (!-s $traits_file)
     {
-	my $page = $c->req->path;
-	if ($page =~ /solgs\/population\/|anova\/|correlation\/|acronyms/ && $pop_id !~ /\D+/)
-	{
-	    $self->save_single_trial_traits($c, $pop_id);
-	}
+        my $page = $c->req->path;
+        if ($page =~ /solgs\/population\/|anova\/|correlation\/|acronyms/ && $pop_id !~ /\D+/)
+        {
+            $self->save_single_trial_traits($c, $pop_id);
+        }
     }
 
     my $traits = read_file($traits_file, {binmode => ':utf8'});
@@ -192,11 +192,20 @@ sub get_all_traits {
 
     unless (-s $acronym_file)
     {
-	my @filtered_traits = split(/\t/, $traits);
-	my $acronymized_traits = $c->controller('solGS::Utils')->acronymize_traits(\@filtered_traits);
-	my $acronym_table = $acronymized_traits->{acronym_table};
+        my $acronym_data;
+        if ($pop_id !~ /\D+/) {
+            my $raw_traits = $c->controller('solGS::Search')->model($c)->trial_traits($pop_id);
+            my $clean_traits = $c->controller('solGS::Utils')->remove_ontology($raw_traits);
+            $acronym_data = $c->controller('solGS::Utils')->acronymize_traits($clean_traits);
+        } else {
+            my @filtered_traits = split(/\t/, $traits);
+            my $synonyms_map = $c->controller('solGS::Search')->model($c)->get_traits_synonyms(\@filtered_traits);
+            $acronym_data = $c->controller('solGS::Utils')->acronymize_traits(\@filtered_traits, $synonyms_map);
+        }
 
-	$self->traits_acronym_table($c, $acronym_table, $pop_id);
+        my $acronym_table = $acronym_data->{acronym_table};
+
+        $self->traits_acronym_table($c, $acronym_table, $pop_id);
     }
 
     $self->create_trait_data($c, $pop_id);

--- a/lib/SGN/Controller/solGS/Utils.pm
+++ b/lib/SGN/Controller/solGS/Utils.pm
@@ -199,9 +199,25 @@ sub abbreviate_term {
 
 }
 
+sub get_best_synonym {
+    my ($self, $name, $synonyms) = @_;
+    my $best;
+    if ($synonyms && ref($synonyms) eq 'ARRAY') {
+        foreach my $s (@$synonyms) {
+            if ($s && $s !~ /[\s\|:]/ && length($s) < 15) {
+                if (!$best || length($s) < length($best)) {
+                    $best = $s;
+                }
+            }
+        }
+    }
+    $best ||= $self->abbreviate_term($name);
+    return $best;
+}
 
 sub acronymize_traits {
-    my ($self, $traits) = @_;
+    my ($self, $traits, $synonyms_map) = @_;
+    $synonyms_map //= {};
 
     my $acronym_table = {};
     my $cnt = 0;
@@ -209,19 +225,29 @@ sub acronymize_traits {
 
     no warnings 'uninitialized';
 
-    foreach my $trait_name (@$traits)
+    foreach my $trait (@$traits)
     {
 	$cnt++;
 
-        my $abbr = $self->abbreviate_term($trait_name);
+        my ($trait_name, $syns);
+        if (ref($trait) eq 'HASH') {
+            $trait_name = $trait->{name};
+            $syns = $trait->{synonyms};
+        } else {
+            $trait_name = $trait;
+            $syns = $synonyms_map->{$trait_name};
+        }
 
-	$abbr = $abbr . '.2' if $cnt > 1 && $acronym_table->{$abbr};
+        my $abbr = $self->get_best_synonym($trait_name, $syns);
+
+        if ($acronym_table->{$abbr}) {
+            $abbr = $abbr . ".$cnt";
+        }
 
         $acronymized_traits .= $abbr;
 	$acronymized_traits .= "\t" unless $cnt == scalar(@$traits);
 
         $acronym_table->{$abbr} = $trait_name if $abbr;
-	my $tr_h = $acronym_table->{$abbr};
     }
 
     my $acronym_data = {
@@ -263,7 +289,7 @@ sub remove_ontology {
 
     foreach my $tr (@$traits)
 	{
-        my $id_nm = {'id' => $tr->[0], 'name' => $tr->[1]};
+        my $id_nm = {'id' => $tr->[0], 'name' => $tr->[1], 'synonyms' => $tr->[6] || [] };
         push @clean_traits, $id_nm;
     }
 

--- a/lib/SGN/Controller/solGS/Utils.pm
+++ b/lib/SGN/Controller/solGS/Utils.pm
@@ -230,7 +230,7 @@ sub get_short_synonym {
             }
         }
     }
-    $best ||= $self->abbreviate_term($name);
+    $best ||= $name;
     return $best;
 }
 

--- a/lib/SGN/Controller/solGS/Utils.pm
+++ b/lib/SGN/Controller/solGS/Utils.pm
@@ -204,13 +204,12 @@ sub get_best_synonym {
     my $best;
     if ($synonyms && ref($synonyms) eq 'ARRAY') {
         foreach my $s (@$synonyms) {
-            if ($s && $s !~ /[\s\|:]/ && length($s) < 15) {
-                if (!$best || length($s) < length($best)) {
-                    $best = $s;
-                }
+            if (!$best || length($s) < length($best)) {
+                $best = $s;
             }
         }
     }
+
     $best ||= $self->abbreviate_term($name);
     return $best;
 }
@@ -227,7 +226,7 @@ sub acronymize_traits {
 
     foreach my $trait (@$traits)
     {
-	$cnt++;
+	    $cnt++;
 
         my ($trait_name, $syns);
         if (ref($trait) eq 'HASH') {
@@ -245,14 +244,14 @@ sub acronymize_traits {
         }
 
         $acronymized_traits .= $abbr;
-	$acronymized_traits .= "\t" unless $cnt == scalar(@$traits);
+	    $acronymized_traits .= "\t" unless $cnt == scalar(@$traits);
 
         $acronym_table->{$abbr} = $trait_name if $abbr;
     }
 
     my $acronym_data = {
-	'acronymized_traits' => $acronymized_traits,
-	'acronym_table'      => $acronym_table
+        'acronymized_traits' => $acronymized_traits,
+        'acronym_table'      => $acronym_table
     };
 
     return $acronym_data;

--- a/lib/SGN/Controller/solGS/Utils.pm
+++ b/lib/SGN/Controller/solGS/Utils.pm
@@ -263,11 +263,8 @@ sub remove_ontology {
 
     foreach my $tr (@$traits)
 	{
-		my $name = $tr->[1];
-		$name= $self->clean_traits($name);
-
-	my $id_nm = {'id' => $tr->[0], 'name' => $name};
- 	push @clean_traits, $id_nm;
+        my $id_nm = {'id' => $tr->[0], 'name' => $tr->[1]};
+        push @clean_traits, $id_nm;
     }
 
     return \@clean_traits;

--- a/lib/SGN/Controller/solGS/Utils.pm
+++ b/lib/SGN/Controller/solGS/Utils.pm
@@ -199,17 +199,37 @@ sub abbreviate_term {
 
 }
 
-sub get_best_synonym {
+sub synonym_remove_obo {
+    my ($self, $synonym) = @_;
+
+    # Clean OBO format: "synonym" SCOPE [xrefs]
+    $synonym =~ s/\R/ /g; # Remove newlines
+    if ($synonym =~ /^"(.*)"/) {
+        $synonym = $1; # Extract content inside quotes
+    } else {
+        # Fallback: remove scope and xrefs if quotes are missing
+        $synonym =~ s/\s+(EXACT|BROAD|NARROW|RELATED).*$//i;
+    }
+    $synonym =~ s/^\s+|\s+$//g; # Trim
+
+    return $synonym;
+}
+
+sub get_short_synonym {
     my ($self, $name, $synonyms) = @_;
     my $best;
+
     if ($synonyms && ref($synonyms) eq 'ARRAY') {
         foreach my $s (@$synonyms) {
-            if (!$best || length($s) < length($best)) {
-                $best = $s;
+            $s = $self->synonym_remove_obo($s);
+            # Only use as 'best' if it's suitable for a header (no spaces/special chars)
+            if ($s && $s !~ /[\s\|:]/) {
+                if (!$best || length($s) < length($best)) {
+                    $best = $s;
+                }
             }
         }
     }
-
     $best ||= $self->abbreviate_term($name);
     return $best;
 }
@@ -237,7 +257,7 @@ sub acronymize_traits {
             $syns = $synonyms_map->{$trait_name};
         }
 
-        my $abbr = $self->get_best_synonym($trait_name, $syns);
+        my $abbr = $self->get_short_synonym($trait_name, $syns);
 
         if ($acronym_table->{$abbr}) {
             $abbr = $abbr . ".$cnt";

--- a/lib/SGN/Controller/solGS/Utils.pm
+++ b/lib/SGN/Controller/solGS/Utils.pm
@@ -222,11 +222,8 @@ sub get_short_synonym {
     if ($synonyms && ref($synonyms) eq 'ARRAY') {
         foreach my $s (@$synonyms) {
             $s = $self->synonym_remove_obo($s);
-            # Only use as 'best' if it's suitable for a header (no spaces/special chars)
-            if ($s && $s !~ /[\s\|:]/) {
-                if (!$best || length($s) < length($best)) {
-                    $best = $s;
-                }
+            if ($s && (!$best || length($s) < length($best))) {
+                $best = $s;
             }
         }
     }

--- a/lib/SGN/Controller/solGS/solGS.pm
+++ b/lib/SGN/Controller/solGS/solGS.pm
@@ -1383,7 +1383,7 @@ sub format_phenotype_dataset_headers {
     foreach my $hd (@headers) {
         my $acronym;
         foreach my $acr ( keys %$acronym_table ) {
-            $acronym = $acr if $acronym_table->{$acr} =~ /$hd/;
+            $acronym = $acr if $acronym_table->{$acr} eq $hd;
             last if $acronym;
         }
 

--- a/lib/SGN/Controller/solGS/solGS.pm
+++ b/lib/SGN/Controller/solGS/solGS.pm
@@ -1362,8 +1362,6 @@ sub format_phenotype_dataset_rows {
 sub format_phenotype_dataset_headers {
     my ( $self, $all_headers, $meta_headers, $traits_file, $synonyms_map ) = @_;
 
-    $all_headers = SGN::Controller::solGS::Utils->clean_traits($all_headers);
-
     my $traits = $all_headers;
 
     foreach my $mh (@$meta_headers) {

--- a/lib/SGN/Controller/solGS/solGS.pm
+++ b/lib/SGN/Controller/solGS/solGS.pm
@@ -1335,14 +1335,14 @@ sub phenotype_file {
 }
 
 sub format_phenotype_dataset {
-    my ( $self, $data_ref, $metadata, $traits_file ) = @_;
+    my ( $self, $data_ref, $metadata, $traits_file, $synonyms_map ) = @_;
 
     my $data = $$data_ref;
     my @rows = split( /\n/, $data );
 
     my $formatted_headers =
       $self->format_phenotype_dataset_headers( $rows[0], $metadata,
-        $traits_file );
+        $traits_file, $synonyms_map );
     $rows[0] = $formatted_headers;
 
     my $formatted_dataset = $self->format_phenotype_dataset_rows( \@rows );
@@ -1360,7 +1360,7 @@ sub format_phenotype_dataset_rows {
 }
 
 sub format_phenotype_dataset_headers {
-    my ( $self, $all_headers, $meta_headers, $traits_file ) = @_;
+    my ( $self, $all_headers, $meta_headers, $traits_file, $synonyms_map ) = @_;
 
     $all_headers = SGN::Controller::solGS::Utils->clean_traits($all_headers);
 
@@ -1376,7 +1376,7 @@ sub format_phenotype_dataset_headers {
     my @filtered_traits = split( /\t/, $traits );
 
     my $acronymized_traits =
-      SGN::Controller::solGS::Utils->acronymize_traits( \@filtered_traits );
+      SGN::Controller::solGS::Utils->acronymize_traits( \@filtered_traits, $synonyms_map );
     my $acronym_table = $acronymized_traits->{acronym_table};
 
     my $formatted_headers;

--- a/lib/SGN/Model/solGS/solGS.pm
+++ b/lib/SGN/Model/solGS/solGS.pm
@@ -2194,6 +2194,39 @@ sub get_dataset_genotype_data {
 
 }
 
+sub get_traits_synonyms {
+    my ($self, $trait_names) = @_;
+    return {} if !$trait_names || !@$trait_names;
+
+    my @names = uniq(@$trait_names);
+
+    my $q = "SELECT (((cvterm.name::text || '|'::text) || db.name::text) || ':'::text) || dbxref.accession::text AS trait_full, 
+                    cvterm.name as trait_short, 
+                    COALESCE(synonyms_table.synonyms, '[]'::jsonb)
+             FROM cvterm
+             JOIN dbxref USING (dbxref_id)
+             JOIN db USING (db_id)
+             LEFT JOIN (
+                 SELECT cvterm_id, jsonb_agg(synonym) as synonyms 
+                 FROM cvtermsynonym 
+                 GROUP BY cvterm_id
+             ) AS synonyms_table ON (cvterm.cvterm_id = synonyms_table.cvterm_id)
+             WHERE (((cvterm.name::text || '|'::text) || db.name::text) || ':'::text) || dbxref.accession::text IN (" . join(',', map { '?' } @names) . ")
+             OR cvterm.name IN (" . join(',', map { '?' } @names) . ");";
+
+    my $sth = $self->schema->storage->dbh->prepare($q);
+    $sth->execute(@names, @names);
+
+    my %map;
+    while (my ($full, $short, $syns_json) = $sth->fetchrow_array()) {
+        my $syns = JSON::Any->new->decode($syns_json);
+        $map{$full} = $syns;
+        $map{$short} = $syns;
+    }
+    return \%map;
+}
+
+
 __PACKAGE__->meta->make_immutable;
 
 #####

--- a/lib/solGS/queryJobs.pm
+++ b/lib/solGS/queryJobs.pm
@@ -175,9 +175,20 @@ sub trial_phenotype_data {
     my $pheno_data = $model->phenotype_data($pop_id);
     my $metadata   = $model->trial_metadata();
 
+    my $synonyms_map;
+    if ($pop_id !~ /\D+/)
+    {
+        my $traits_raw = $model->trial_traits($pop_id);
+        my $clean = SGN::Controller::solGS::Utils->remove_ontology($traits_raw);
+        foreach my $tr (@$clean)
+        {
+            $synonyms_map->{$tr->{name}} = $tr->{synonyms};
+        }
+    }
+
     if ($pheno_data)
     {
-	my $pheno_data = SGN::Controller::solGS::solGS->format_phenotype_dataset($pheno_data, $metadata, $traits_file);
+	my $pheno_data = SGN::Controller::solGS::solGS->format_phenotype_dataset($pheno_data, $metadata, $traits_file, $synonyms_map);
 	write_file($pheno_file, {binmode => ':utf8'}, $pheno_data);
     }
 
@@ -222,7 +233,17 @@ sub plots_list_phenotype_data {
     my $pheno_data = $model->plots_list_phenotype_data($plots_ids);
     my $metadata = $model->trial_metadata();
 
-    $pheno_data = SGN::Controller::solGS::solGS->format_phenotype_dataset($pheno_data, $metadata, $traits_file);
+    my $synonyms_map;
+    if ($pheno_data && $$pheno_data) {
+        my @rows = split(/\n/, $$pheno_data, 2);
+        if (@rows) {
+            my @headers = split(/\t/, $rows[0]);
+            my @trait_names = grep { /\|/ } @headers;
+            $synonyms_map = $model->get_traits_synonyms(\@trait_names);
+        }
+    }
+
+    $pheno_data = SGN::Controller::solGS::solGS->format_phenotype_dataset($pheno_data, $metadata, $traits_file, $synonyms_map);
 
     write_file($pheno_file, {binmode => ':utf8'}, $pheno_data);
     write_file($metadata_file, {binmode => ':utf8'}, join("\t", @$metadata));

--- a/t/unit_fixture/CXGN/Trial/DeriveTrait.t
+++ b/t/unit_fixture/CXGN/Trial/DeriveTrait.t
@@ -160,7 +160,7 @@ print STDERR Dumper \@traits_assayed_sorted;
 is_deeply(\@traits_assayed_sorted, [
           [
             70741,
-            'dry matter content percentage|CO_334:0000092', [], 3, undef, undef
+            'dry matter content percentage|CO_334:0000092', [], 3, undef, undef, ['"dm" EXACT []', '"DMCt_Comp_r" EXACT []']
           ]
         ], "check upload worked");
 

--- a/t/unit_fixture/CXGN/Uploading/Phenotype.t
+++ b/t/unit_fixture/CXGN/Uploading/Phenotype.t
@@ -172,7 +172,12 @@ my $traits_assayed  = $tn->get_traits_assayed(); # returns the counts assayed
 my @traits_assayed_sorted = sort {$a->[0] cmp $b->[0]} @$traits_assayed;
 print STDERR Dumper @traits_assayed_sorted;
 
-my @traits_assayed_check = ([70666,'fresh root weight|CO_334:0000012', [], 15,undef,undef], [70668,'harvest index variable|CO_334:0000015', [], 15,undef,undef], [70741,'dry matter content percentage|CO_334:0000092', [], 15,undef,undef], [70773,'fresh shoot weight measurement in kg|CO_334:0000016', [], 15,undef,undef]);
+my @traits_assayed_check = (
+	[70666,'fresh root weight|CO_334:0000012', [], 15,undef,undef, ['"rtwt" EXACT []','"RtWt_Wgh_kg" EXACT []']],
+	[70668,'harvest index variable|CO_334:0000015', [], 15,undef,undef, ['"HI" EXACT []']],
+	[70741,'dry matter content percentage|CO_334:0000092', [], 15,undef,undef, ['"dm" EXACT []','"DMCt_Comp_r" EXACT []']],
+	[70773,'fresh shoot weight measurement in kg|CO_334:0000016', [], 15,undef,undef, ['"shtwt" EXACT []','"ShWt_Meas_kg" EXACT []']]
+);
 
 is_deeply(\@traits_assayed_sorted, \@traits_assayed_check, 'check traits assayed from phenotyping spreadsheet upload 1' );
 
@@ -588,7 +593,12 @@ my $tn = CXGN::Trial->new( { bcs_schema => $f->bcs_schema(),
 my $traits_assayed  = $tn->get_traits_assayed(); # returns the counts assayed
 my @traits_assayed_sorted = sort {$a->[0] cmp $b->[0]} @$traits_assayed;
 print STDERR "TRAITS ASSAYED UPDATE 3: ".Dumper @traits_assayed_sorted;
-my @traits_assayed_check = ([70666,'fresh root weight|CO_334:0000012', [], 15,undef,undef], [70668,'harvest index variable|CO_334:0000015', [], 15,undef,undef], [70741,'dry matter content percentage|CO_334:0000092', [], 15,undef,undef], [70773,'fresh shoot weight measurement in kg|CO_334:0000016', [], 15,undef,undef]);
+my @traits_assayed_check = (
+	[70666,'fresh root weight|CO_334:0000012', [], 15,undef,undef, ['"rtwt" EXACT []','"RtWt_Wgh_kg" EXACT []']],
+	[70668,'harvest index variable|CO_334:0000015', [], 15,undef,undef, ['"HI" EXACT []']],
+	[70741,'dry matter content percentage|CO_334:0000092', [], 15,undef,undef, ['"dm" EXACT []','"DMCt_Comp_r" EXACT []']],
+	[70773,'fresh shoot weight measurement in kg|CO_334:0000016', [], 15,undef,undef, ['"shtwt" EXACT []','"ShWt_Meas_kg" EXACT []']]
+);
 is_deeply(\@traits_assayed_sorted, \@traits_assayed_check, 'check traits assayed from phenotyping spreadsheet upload update' );
 
 my @pheno_for_trait = $tn->get_phenotypes_for_trait(70666);
@@ -714,19 +724,19 @@ ok(!$image_error, "check no error in image upload");
  print STDERR "\n\nTRAITS ASSAYED SORTED UPLOAD 3: ". Dumper \@traits_assayed_sorted;
  @traits_assayed_check = ([
            70666,
-           'fresh root weight|CO_334:0000012', [], 15,undef,undef
+           'fresh root weight|CO_334:0000012', [], 15,undef,undef, ['"rtwt" EXACT []', '"RtWt_Wgh_kg" EXACT []']
          ],[
            70668,
-           'harvest index variable|CO_334:0000015', [], 15,undef,undef
+           'harvest index variable|CO_334:0000015', [], 15,undef,undef, ['"HI" EXACT []']
          ],[
            70727,
-           'dry yield|CO_334:0000014', [], 15,undef,undef
+           'dry yield|CO_334:0000014', [], 15,undef,undef, ['"dyld" EXACT []','"RtYld_Dry_tha" EXACT []']
          ],[
            70741,
-           'dry matter content percentage|CO_334:0000092', [], 15,undef,undef
+           'dry matter content percentage|CO_334:0000092', [], 15,undef,undef, ['"dm" EXACT []','"DMCt_Comp_r" EXACT []']
          ],[
            70773,
-           'fresh shoot weight measurement in kg|CO_334:0000016', [], 15,undef,undef
+           'fresh shoot weight measurement in kg|CO_334:0000016', [], 15,undef,undef, ['"shtwt" EXACT []','"ShWt_Meas_kg" EXACT []']
          ]);
 
  is_deeply(\@traits_assayed_sorted, \@traits_assayed_check, 'check traits assayed from phenotyping spreadsheet upload 3' );
@@ -1193,7 +1203,13 @@ print STDERR "DATA COLLECTOR CHECK STORED DATA: ". Dumper \@traits_assayed_sorte
 
 #         );
 
-@traits_assayed_check = ([70666,'fresh root weight|CO_334:0000012',[],14,undef,undef],[70668,'harvest index variable|CO_334:0000015',[],15,undef,undef],[70727,'dry yield|CO_334:0000014',[],15,undef,undef],[70741,'dry matter content percentage|CO_334:0000092',[],13,undef,undef],[70773,'fresh shoot weight measurement in kg|CO_334:0000016',[],15,undef,undef]);
+@traits_assayed_check = (
+	[70666,'fresh root weight|CO_334:0000012',[],14,undef,undef,['"rtwt" EXACT []', '"RtWt_Wgh_kg" EXACT []']],
+	[70668,'harvest index variable|CO_334:0000015',[],15,undef,undef,['"HI" EXACT []']],
+	[70727,'dry yield|CO_334:0000014',[],15,undef,undef,['"dyld" EXACT []','"RtYld_Dry_tha" EXACT []']],
+	[70741,'dry matter content percentage|CO_334:0000092',[],13,undef,undef,['"dm" EXACT []','"DMCt_Comp_r" EXACT []']],
+	[70773,'fresh shoot weight measurement in kg|CO_334:0000016',[],15,undef,undef,['"shtwt" EXACT []','"ShWt_Meas_kg" EXACT []']]
+);
 
 
 is_deeply(\@traits_assayed_sorted, \@traits_assayed_check, 'check traits assayed from data collector upload 4' );

--- a/t/unit_fixture/CXGN/Uploading/Phenotype_plants.t
+++ b/t/unit_fixture/CXGN/Uploading/Phenotype_plants.t
@@ -118,7 +118,8 @@ my @traits_expected = (
             [],
             29,
             undef,
-            undef
+            undef,
+            ['"rtwt" EXACT []', '"RtWt_Wgh_kg" EXACT []'],
           ],
           [
             70741,
@@ -126,7 +127,8 @@ my @traits_expected = (
             [],
             29,
             undef,
-            undef
+            undef,
+            ['"dm" EXACT []','"DMCt_Comp_r" EXACT []'],
           ]
     );
 
@@ -244,7 +246,8 @@ is_deeply(\@traits_assayed_sorted, [
             [],
             29,
             undef,
-            undef
+            undef,
+            ['"rtwt" EXACT []', '"RtWt_Wgh_kg" EXACT []']
           ],
           [
             70727,
@@ -252,7 +255,8 @@ is_deeply(\@traits_assayed_sorted, [
             [],
             4,
             undef,
-            undef
+            undef,
+            ['"dyld" EXACT []','"RtYld_Dry_tha" EXACT []']
           ],
           [
             70741,
@@ -260,7 +264,8 @@ is_deeply(\@traits_assayed_sorted, [
             [],
             29,
             undef,
-            undef
+            undef,
+            ['"dm" EXACT []','"DMCt_Comp_r" EXACT []']
           ]
 	  ]
 

--- a/t/unit_mech/AJAX/BreedersToolbox/TrialMetadata.t
+++ b/t/unit_mech/AJAX/BreedersToolbox/TrialMetadata.t
@@ -64,8 +64,14 @@ is_deeply($response, {'phenotypes_fully_uploaded'=>1}, "get upload feedback");
 
 $mech->get_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/traits_assayed');
 $response = decode_json $mech->content;
-#print STDERR Dumper $response;
-is_deeply($response, {'traits_assayed' => [[[70741,'dry matter content percentage|CO_334:0000092', [], 464, undef, undef],[70666,'fresh root weight|CO_334:0000012', [], 469, undef, undef],[70773,'fresh shoot weight measurement in kg|CO_334:0000016', [], 494, undef, undef]]]}, "check assayed trait uploaded" );
+print STDERR Dumper $response;
+is_deeply($response, {'traits_assayed' => [
+    [
+        [70741,'dry matter content percentage|CO_334:0000092', [], 464, undef, undef, ['"dm" EXACT []', '"DMCt_Comp_r" EXACT []']],
+        [70666,'fresh root weight|CO_334:0000012', [], 469, undef, undef, ['"rtwt" EXACT []', '"RtWt_Wgh_kg" EXACT []']],
+        [70773,'fresh shoot weight measurement in kg|CO_334:0000016', [], 494, undef, undef, ['"shtwt" EXACT []', '"ShWt_Meas_kg" EXACT []']]
+    ]
+]}, "check assayed trait uploaded" );
 
 my $trait_id = 70741;
 $mech->get_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/heatmap?selected='.$trait_id );


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Trait synonyms are now used instead of acronyms. Closes https://github.com/BFF-AFIRMS/sgn/issues/50


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
