### PR TITLE
fieldmap: remove fixed width from button wrapper

### DIFF
--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -64,7 +64,6 @@ $trial_stock_type => undef
 
     .interactive_fieldmap_buttons {
         margin-top: 4%;
-        width: 405px;
         margin-left: auto;
         margin-right: auto;
     }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

The style setting this width is from 2022 so I am unsure why these buttons only now began having this "squished together" issue. Regardless, removing the fixed width solves the issue.

Before:
<img width="1313" height="392" alt="Screenshot 2026-05-27 094020" src="https://github.com/user-attachments/assets/c05cefa2-4fe2-4af8-9eef-a69b0987e15e" />

After:
<img width="1300" height="276" alt="Screenshot 2026-05-27 094130" src="https://github.com/user-attachments/assets/bf23e288-3245-443c-8330-b6e4821aba13" />


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
