### PR TITLE
Styles: Fix overlapping components and consistify trial sections

### DIFF
--- a/js/source/legacy/CXGN/Trial.js
+++ b/js/source/legacy/CXGN/Trial.js
@@ -306,10 +306,12 @@ function edit_trial_details(){
     get_select_box('years', 'edit_trial_year', { 'default' : default_year, 'auto_generate': 1 });
     jQuery('#edit_trial_year').data("originalValue", default_year);
 
-    var default_year_0 = document.getElementById("edit_trial_year_0").getAttribute("value");
-    var select_year_0 = default_year_0 != '' ? default_year_0 : default_year;
-    get_select_box('years', 'edit_trial_year_0', { 'default' : select_year_0, 'auto_generate': 1, 'id': 'year_0_select', 'name': 'year_0_select' });
-    jQuery('#edit_trial_year_0').data("originalValue", default_year_0);
+    if (document.getElementById("edit_trial_year_0")) {
+        var default_year_0 = document.getElementById("edit_trial_year_0").getAttribute("value");
+        var select_year_0 = default_year_0 != '' ? default_year_0 : default_year;
+        get_select_box('years', 'edit_trial_year_0', { 'default' : select_year_0, 'auto_generate': 1, 'id': 'year_0_select', 'name': 'year_0_select' });
+        jQuery('#edit_trial_year_0').data("originalValue", default_year_0);
+    }
 
     var default_type = document.getElementById("edit_trial_type").getAttribute("value");
     get_select_box('trial_types', 'edit_trial_type',  { 'default' : default_type });

--- a/mason/analyses/analysis_details.mas
+++ b/mason/analyses/analysis_details.mas
@@ -10,10 +10,10 @@ $trial_stock_type
 $analysis_metadata
 </%args>
 
-<div class="row">
-    <div class="col-sm-8">
+<div class="row flex-wrap-row">
+    <div class="col-auto">
 
-        <table class="table table-hover table-bordered" >
+        <table class="table table-hover table-bordered table-trial-details" >
 
             <tr>
                 <td><b>Analysis Name</b></td>
@@ -106,7 +106,7 @@ $analysis_metadata
         </table>
 
     </div>
-    <div class="col-sm-4">
+    <div class="col-auto">
         <div class="well well-sm">
             <& /util/barcode.mas, identifier => "$identifier_prefix"."$trial_id", trial_id=> "$trial_id", trial_name=> "$trial_name", format=>"trial_qrcode"  &>
         </div>

--- a/mason/analyses/model_details.mas
+++ b/mason/analyses/model_details.mas
@@ -4,10 +4,10 @@ $trial_name
 $analysis_metadata
 </%args>
 
-<div class="row">
-    <div class="col-sm-12">
+<div class="row flex-wrap-row">
+    <div class="col-auto">
 
-        <table class="table table-hover table-bordered" >
+        <table class="table table-hover table-bordered table-trial-details" >
 
         <tr>
             <td><b>Model Name</b></td>

--- a/mason/breeders_toolbox/cross/crossingtrial_details.mas
+++ b/mason/breeders_toolbox/cross/crossingtrial_details.mas
@@ -16,10 +16,10 @@ $trial_owner
 </%args>
 
 
-<div class="row">
-    <div class="col-sm-8">
+<div class="row flex-wrap-row">
+    <div class="col-auto">
 
-        <table class="table table-hover table-bordered" >
+        <table class="table table-hover table-bordered table-trial-details" >
 
             <tr>
                 <td><b>Crossing Experiment Name</b></td>
@@ -136,7 +136,7 @@ $trial_owner
         </table>
 
     </div>
-    <div class="col-sm-4">
+    <div class="col-auto">
         <div class="well well-sm">
             <& /util/barcode.mas, identifier => "$identifier_prefix"."$trial_id", trial_id=> "$trial_id", trial_name=> "$trial_name", format=>"trial_qrcode"  &>
         </div>

--- a/mason/breeders_toolbox/genotyping_data_project/details.mas
+++ b/mason/breeders_toolbox/genotyping_data_project/details.mas
@@ -12,10 +12,10 @@ $genotype_data_type
 $trial_owner
 </%args>
 
-<div class="row">
-    <div class="col-sm-8">
+<div class="row flex-wrap-row">
+    <div class="col-auto">
 
-        <table class="table table-hover table-bordered" >
+        <table class="table table-hover table-bordered table-trial-details" >
 
             <tr>
                 <td><b>Genotyping Project Name</b></td>
@@ -119,7 +119,7 @@ $trial_owner
         </table>
         
     </div>
-    <div class="col-sm-4">
+    <div class="col-auto">
         <div class="well well-sm">
             <& /util/barcode.mas, identifier => "$identifier_prefix"."$trial_id", trial_id=> "$trial_id", trial_name=> "$trial_name", format=>"trial_qrcode"  &>
         </div>

--- a/mason/breeders_toolbox/trial.mas
+++ b/mason/breeders_toolbox/trial.mas
@@ -100,11 +100,11 @@ $project_id => undef
 <script  src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
 <script  src="https://cdn.datatables.net/buttons/2.3.2/js/buttons.html5.min.js"></script>
 
-<div class="row">
-    <div class="col-sm-6">
+<div class="row flex-wrap-row">
+    <div class="col-auto">
         <& /page/detail_page_3_col_section.mas, icon_class => "glyphicon glyphicon-qrcode", title => $barcode_section_title, label_design_btn_id => "label_designer_link", legacy_barcode_btn_id => "generate_trial_barcode_link" &>
     </div>
-    <div class="col-sm-6">
+    <div class="col-auto">
         <& /page/detail_page_3_col_section.mas, icon_class => "glyphicon glyphicon-pencil", title => "Directly record phenotypes to database for this trial.", go_btn_id => "direct_phenotyping_link" &>
     </div>
 </div>

--- a/mason/breeders_toolbox/trial/design_section.mas
+++ b/mason/breeders_toolbox/trial/design_section.mas
@@ -13,7 +13,6 @@ $user_can_modify => undef
 
 </style>
 
-<div class="well well-sm">
 
     <& /breeders_toolbox/trial/design.mas, trial_id => $trial_id &>
 % my $stock_label = '';
@@ -33,11 +32,11 @@ $user_can_modify => undef
   </&>
 
   <& /breeders_toolbox/trial/trial_stocks_count.mas, trial_id => $trial_id &>
+
   <&| /page/info_section.mas, id => "trial_stocks", title=> $stock_label, subtitle => '<div class="col-sm-4"><div id="stocks_counts"></div></div>',is_subsection => 1, collapsible=>1, collapsed=>1 &>
-
-      <& /breeders_toolbox/trial/trial_stocks.mas, trial_id => $trial_id &>
-
+        <& /breeders_toolbox/trial/trial_stocks.mas, trial_id => $trial_id &>
   </&>
+
 
 
     <&| /page/info_section.mas, id => "trial_seedlots", title=>"Seedlots", subtitle => '<div class="col-sm-4"><div id="seedlots_counts"></div></div>', is_subsection => 1, collapsible=>1, collapsed=>1 &>
@@ -133,7 +132,3 @@ $user_can_modify => undef
     <&| /page/info_section.mas, id=>"trial_entry_numbers", title=>"Entry Numbers", is_subsection=>1, collapsible=>1, collapsed=>1 &>
         <& /breeders_toolbox/trial/trial_entry_numbers.mas, trial_id => $trial_id, trial_name => $trial_name &>
     </&>
-
-
-
-</div><!-- closes well -->

--- a/mason/breeders_toolbox/trial/files_section.mas
+++ b/mason/breeders_toolbox/trial/files_section.mas
@@ -4,10 +4,6 @@ $trial_stock_type => undef
 $for_analysis_page => undef
 </%args>
 
-<div class="well well-sm">
-
-    <div class="panel panel-default">
-        <div class="panel-body">
             <&| /page/info_section.mas, title=>"Data Collection Files", is_subsection => 1, collapsible=>1, collapsed=>0, &>
                 <&| /page/info_section.mas, title=>"Phenotyping Spreadsheets", empty_message=>'', is_subsection => 1, collapsible=>0, collapsed=>0, subtitle=>'<button class="btn btn-sm btn-default" style="margin:3px" name="create_spreadsheet_link">Create Spreadsheet</button>' &>
                 </&>
@@ -18,10 +14,7 @@ $for_analysis_page => undef
                 </&>
 %  }
             </&><!-- closes create new phenotyping file section -->
-        </div>
-    </div>
-    <div class="panel panel-default">
-        <div class="panel-body">
+
             <&| /page/info_section.mas, title=>"Upload Phenotyping Files", is_subsection => 1, collapsible=>1, collapsed=>0, &>
                 <&| /page/info_section.mas, title=>"Phenotyping Spreadsheets", empty_message=>'', is_subsection => 1, collapsible=>0, collapsed=>0, subtitle=>'<button class="btn btn-sm btn-primary" style="margin:3px" id="upload_spreadsheet_phenotypes_link">Upload</button>'&>
                 </&>
@@ -32,29 +25,20 @@ $for_analysis_page => undef
                 </&>
 %  }
             </&><!-- closes upload new phenotype file section -->
-        </div>
-    </div>
-    <div class="panel panel-default">
-        <div class="panel-body">
+
             <&| /page/info_section.mas, title=>"Uploaded Phenotyping Files", is_subsection => 1, collapsible=>1, collapsed=>0 &>
 
                 <table class="table table-bordered" id="trial_phenotype_files_datatables" alt="">
                 </table>
 
             </&><!-- closes uploaded file section -->
-        </div>
-    </div>
-    <div class="panel panel-default">
-        <div class="panel-body">
+
             <&| /page/info_section.mas, title=>"Uploaded Additional Files", is_subsection => 1, collapsible=>1, collapsed=>0, subtitle=>'<button class="btn btn-sm btn-primary" style="margin:3px" id="trial_upload_additional_files_link">Upload Additional Files</button>' &>
 
             <& /breeders_toolbox/trial/upload_additional_file.mas, trial_id => $trial_id &>
 
             </&><!-- closes uploaded additional file section -->
-        </div>
-    </div>
 
-</div><!-- closes well -->
 
 <script>
 jQuery(document).ready(function() {
@@ -62,6 +46,7 @@ jQuery(document).ready(function() {
 
         jQuery('#trial_phenotype_files_datatables').DataTable({
             'ajax': { 'url': '/ajax/breeders/trial/<% $trial_id %>/phenotype_metadata' },
+            'scrollX': true,
             columns: [
                 { title: "Filename", "data": null, "render": function ( data, type, row ) { return row[4]; } },
                 { title: "Date Uploaded", "data": null, "render": function ( data, type, row ) { return row[1]; } },

--- a/mason/breeders_toolbox/trial/trial_audit.mas
+++ b/mason/breeders_toolbox/trial/trial_audit.mas
@@ -41,6 +41,7 @@ $project_id
             }
             jQuery('#audit_results').DataTable({
               data: json_object,
+              scrollX: true,
               columns: [
                   { title: 'Timestamp' },
                     { title: 'Operation' },

--- a/mason/breeders_toolbox/trial/trial_details.mas
+++ b/mason/breeders_toolbox/trial/trial_details.mas
@@ -27,11 +27,18 @@ $latest_trial_activity => undef
 
 </%args>
 
+<style>
+.table-trial-details td:nth-child(2) {
+    white-space: normal;
+    /* Limit the second column width in trial details, so that the QR code is beside it */
+    max-width: 320px;
+}
+</style>
 
 <div class="row flex-wrap-row">
     <div class="col-auto">
 
-        <table class="table table-hover table-bordered" >
+        <table class="table table-hover table-bordered table-trial-details">
 
             <tr>
                 <td><b>Trial Name</b></td>
@@ -90,7 +97,7 @@ $latest_trial_activity => undef
             </tr>
 
             <tr>
-                <td><b>Stock Type Being Evaluated in This Trial</b></td>
+                <td><b>Stock Type in Trial</b></td>
                 <td>
                     <div id="stock_type_in_trial">
 % if ($trial_stock_type) {
@@ -103,7 +110,7 @@ $latest_trial_activity => undef
             </tr>
 
 	    <tr>
-                <td><b>Number of Stocks in This Trial</b></td>
+                <td><b>Number of Stocks</b></td>
                 <td>
                     <div id="stock_number_in_trial">
 % if ($trial_stock_count) {
@@ -166,7 +173,7 @@ $latest_trial_activity => undef
             <tr><td><b>Description</b></td>
                 <td>
 % if ($trial_description) {
-%  print "<div id='trial_description' style='white-space: pre-wrap;'>$trial_description</div>";
+%  print "<div id='trial_description'>$trial_description</div>";
 % } else {
 %  print "<div id='trial_description'><span class='text-danger'>[No Description]</span></div>";
 % }

--- a/mason/breeders_toolbox/trial/trial_details.mas
+++ b/mason/breeders_toolbox/trial/trial_details.mas
@@ -27,14 +27,6 @@ $latest_trial_activity => undef
 
 </%args>
 
-<style>
-.table-trial-details td:nth-child(2) {
-    white-space: normal;
-    /* Limit the second column width in trial details, so that the QR code is beside it */
-    max-width: 320px;
-}
-</style>
-
 <div class="row flex-wrap-row">
     <div class="col-auto">
 

--- a/mason/breeders_toolbox/trial/trial_nirs_data.mas
+++ b/mason/breeders_toolbox/trial/trial_nirs_data.mas
@@ -23,7 +23,7 @@ $stockref => undef
     }
 </style>
 
-<div class="well well-sm" id="nirs_analysis_plot_spectra_protocol_select">
+<div id="nirs_analysis_plot_spectra_protocol_select">
 </div>
 
 <center>

--- a/mason/breeders_toolbox/trial/trial_soil_data.mas
+++ b/mason/breeders_toolbox/trial/trial_soil_data.mas
@@ -7,18 +7,10 @@ $trial_id
 
 
 
-<&| /page/info_section.mas, title => "Trial Soil Data", collapsible=>1, collapsed=>0 &>
-    <div class = "well well-sm">
-        <div class = "panel panel-default">
-            <div class = "panel-body">
-                <div style="overflow:scroll">
-                    <table id = "soil_data_table" class="table table-hover table-striped">
-                    </table>
-                </div>
-            </div>
-        </div>
-    </div>
-</&>
+<div>
+    <table id = "soil_data_table" class="table table-hover table-striped">
+    </table>
+</div>
 
 <script defer="defer">
 

--- a/mason/breeders_toolbox/trial/trial_status.mas
+++ b/mason/breeders_toolbox/trial/trial_status.mas
@@ -26,24 +26,16 @@ $user_can_modify => undef
 
 
 <&| /page/info_section.mas, title => "Trial Activities", collapsible=>1, collapsed=>0 &>
-    <div class = "well well-sm">
-        <div class = "panel panel-default">
-            <div class = "panel-body">
-                <table id = "trial_activities_table" class="table table-hover table-striped">
-                    <thead>
-                        <tr>
-                            <th>Status Type</th>
-                            <th>Date</th>
-                            <th>Updated by</th>
-                        </tr>
-                    </thead>
-                </table>
-            </div>
-        </div>
-    </div>
+    <table id = "trial_activities_table" class="table table-hover table-striped">
+        <thead>
+            <tr>
+                <th>Status Type</th>
+                <th>Date</th>
+                <th>Updated by</th>
+            </tr>
+        </thead>
+    </table>
 </&>
-
-<div class="panel-body">
 
 <&| /page/info_section.mas, id=>"trial_completion_layout_section", title=>"Field Design", collapsible=>1, collapsed=>1 &>
 %  if ($design_name) {
@@ -76,8 +68,6 @@ $user_can_modify => undef
 %  }
 -->
 </&>
-
-</div>
 
 <& /breeders_toolbox/trial/update_trial_status_dialog.mas, trial_id => $trial_id, trial_name => $trial_name, user_name => $user_name &>
 

--- a/mason/image/plot_images.mas
+++ b/mason/image/plot_images.mas
@@ -13,7 +13,6 @@ $stockref => undef
 <& /util/import_javascript.mas, classes => [ 'jquery', 'thickbox', 'jquery.dataTables' ] &>
 
 
-<div class="well well-sm table-responsive">
     <table id="plot_images_results" class="table table-hover table-striped">
     <thead>
         <tr>
@@ -26,7 +25,6 @@ $stockref => undef
     </tr>
     </thead>
     </table>
-</div>
             
 
 <script>

--- a/mason/site/header.mas
+++ b/mason/site/header.mas
@@ -19,8 +19,8 @@
   <!-- START CONTENT WRAPPER -->
   <div id="wrapper" class="container-fluid">
     <div id="main_row" class="row">
-      <div class="col-md-1 col-lg-1 col-xl-2">
+      <div class="col-md-1 col-lg-1">
       </div>
-      <div class="col-sm-12 col-md-10 col-lg-10 col-xl-8">
+      <div class="col-sm-12 col-md-10 col-lg-10">
 
 <& /cookie_popup.mas &>

--- a/mason/site/toolbar.mas
+++ b/mason/site/toolbar.mas
@@ -38,7 +38,7 @@ TreeImprovementBase Modifications
     }
   }
 
-  @media (min-width: 768px) and (max-width: 880px) {
+  @media (min-width: 768px) and (max-width: 916px) {
     body {
       padding-top: 90px;
     }

--- a/static/css/treeimprovementbase.css
+++ b/static/css/treeimprovementbase.css
@@ -748,6 +748,15 @@ Navbar
     background-color: var(--well-background-color);
 }
 
+.trial-header {
+    padding-top: 30px
+}
+@media only screen and (min-width: 768px) and (max-width: 913px) {
+    .trial-header.is-stuck {
+        top: 110px;
+    }
+}
+
 .navbar-default {
     box-shadow: var(--button-box-shadow);
 }

--- a/static/css/treeimprovementbase.css
+++ b/static/css/treeimprovementbase.css
@@ -835,6 +835,12 @@ Table
     border-width: 0px;
 }
 
+.table-trial-details td:nth-child(2) {
+    white-space: normal;
+    /* Limit the second column width in trial details, so that the QR code is beside it */
+    max-width: 320px;
+}
+
 /*.table>tbody>tr>td, */
 
 /*

--- a/static/css/treeimprovementbase.css
+++ b/static/css/treeimprovementbase.css
@@ -546,7 +546,7 @@ Info Sections
 */
 
 div.infosectioncontent {
-    margin: 0px;
+    margin: 10px;
     /* display: flex; */
 }
 

--- a/static/css/treeimprovementbase.css
+++ b/static/css/treeimprovementbase.css
@@ -211,12 +211,16 @@ html, body, #outercontainer {
     padding-top: 50px;
 
     flex-grow: 1;
+
+    /* Space for footer */
+    padding-bottom: 20px;
 }
 
 #pagefooter {
     flex-shrink: 1;
     margin-bottom: 0;
-    min-height: 80px;
+    /* override the default bootstrap min-height to allow footer to exapnd to content height */
+    min-height: unset;
 }
 
 /*

--- a/static/css/treeimprovementbase.css
+++ b/static/css/treeimprovementbase.css
@@ -223,6 +223,11 @@ html, body, #outercontainer {
     min-height: unset;
 }
 
+#main_row {
+    /* Use the full screen width minus parent padding */
+    max-width: calc(100vw - 45px);
+}
+
 /*
 -------------------------------------------------------------------------------
 Barcodes


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR mostly has style fixes aimed at smaller screen sizes, to help prevent overlapping or incorrectly sized components. It has one critical bugfix (#108), because I previously broke editing crossing trial details in the Year 0 PR (#75).

<!-- If there are relevant issues, link them here: -->

- Resolves #108 
- Resolves #80
- Resolves #81
- Resolves #82
- Resolves #106
- Resolves #107
- Resolves #111



## Changes

- **Navbar**: Remove overlaps with very top content on small to medium screen sizes. 

| Before | After
| ------- | ----- |
| <img width="872" height="248" alt="image" src="https://github.com/user-attachments/assets/6018cdd5-ef68-43f8-ab75-b0fa8cea5dca" /> | <img width="720" alt="image" src="https://github.com/user-attachments/assets/b5f342a4-1e50-4b7b-a0be-b8f7e87f0264" /> |

- **Footer**: Fix height to fit content at all screen sizes.

| Before | After
| ------- | ----- |
|  <img width="535" height="173" alt="image" src="https://github.com/user-attachments/assets/3a2ac325-1a6a-401a-82cd-489326c5cf62" /> |<img width="661" height="167" alt="image" src="https://github.com/user-attachments/assets/2aabc328-821e-4ef0-adc6-830ddf73c4d9" />|

- **Cross Details**: Prevent table and QR code from overlapping.

| Before | After |
| ------- | ----- |
| <img width="567" height="417" alt="image" src="https://github.com/user-attachments/assets/989da4fa-0809-4153-904d-4a16a39718f4" /> | <img width="699" alt="image" src="https://github.com/user-attachments/assets/a25c27aa-15f0-40b9-a11f-e3b5bf701572" /> |


- **Trial Sticky Header**: Improve placement to prevent navbar overlaps on small/medium screen sizes.

| Before | After |
| ------- | ----- |
| <img width="777" height="231" alt="image" src="https://github.com/user-attachments/assets/3b274997-b387-4d11-820f-603f56cd273d" />| <img width="752" height="298" alt="image" src="https://github.com/user-attachments/assets/03270517-984c-4107-bd16-3af1c31eb1dd" /> |

- **Trial Details**: Prevent table from taking full width if a really long description was given. Also use shorted column names in column 1 to make the details table more compact.

| Before | After |
| ------- | ----- |
| <img width="670" height="767" alt="image" src="https://github.com/user-attachments/assets/766c524c-b0f6-4ae8-a9d7-b53a2b09b4cf" />| <img width="908" height="573" alt="image" src="https://github.com/user-attachments/assets/abdd4782-7f6b-4f02-92dd-1f2789ef7b35" /> |

- **Trial Status**: Remove nesting in well that clutters UI. Make left alignment of accordion components all the same.

| Before | After |
| ------- | ----- |
| <img width="867" height="737" alt="image" src="https://github.com/user-attachments/assets/d8bda256-eee3-45b1-a923-f0c98243852c" /> | <img width="826" height="581" alt="image" src="https://github.com/user-attachments/assets/3bde9638-7160-4539-96ca-123361b8d841" /> |

- **Trial Experimental Design**: Remove nesting in well that clutters UI.

| Before | After |
| ------- | ----- |
|<img width="867" height="811" alt="image" src="https://github.com/user-attachments/assets/2e5c7efd-4249-4ecf-b80a-1f0948e4c67e" />| <img width="869" height="746" alt="image" src="https://github.com/user-attachments/assets/25b80015-b0d9-4357-ba61-c875e26c8f2f" /> |




Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
