### PR TITLE
lists: change list table group column name to select

### DIFF
--- a/js/source/legacy/CXGN/List.js
+++ b/js/source/legacy/CXGN/List.js
@@ -408,7 +408,7 @@ CXGN.List.prototype = {
 
         // List Table
         html += '<table id="private_list_data_table" class="table table-hover table-condensed">';
-        html += '<thead><tr><th>List Name</th><th>Description</th><th>Date Created</th><th>Date Modified</th><th>Count</th><th>Type</th><th>Validate</th><th>View</th><th>Delete</th><th>Download</th><th>Share</th><th>Group</th></tr></thead><tbody>';
+        html += '<thead><tr><th>List Name</th><th>Description</th><th>Date Created</th><th>Date Modified</th><th>Count</th><th>Type</th><th>Validate</th><th>View</th><th>Delete</th><th>Download</th><th>Share</th><th>Select</th></tr></thead><tbody>';
         for (var i = 0; i < lists.length; i++) {
             if ( (!type || type === lists[i][5]) && (autocreated || !(lists[i][2] || '').startsWith("Autocreated")) ) {
                 html += '<tr><td><a href="javascript:showListItems(\'list_item_dialog\','+lists[i][0]+')"><b>'+lists[i][1]+'</b></a></td>';


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR changes the final column of the Lists table to be named **Select** instead of **Group**. This was a user feedback request, to make it clearer that clicking that checkbox will enable additional options such as multiple delete.

<!-- If there are relevant issues, link them here: -->
- Resolves #96 

| Before | After |
| ------- | ------ |
| <img width="1053" height="322" alt="image" src="https://github.com/user-attachments/assets/cb159b03-e772-44ec-aea9-c97be6db6bba" />| <img width="1039" height="320" alt="image" src="https://github.com/user-attachments/assets/6c74ad3b-9e31-4a5a-bc6e-ac69566d60ea" /> |

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
