### PR TITLE
styles: temporary fix for datatables scrollX problems

### DIFF
--- a/static/css/treeimprovementbase.css
+++ b/static/css/treeimprovementbase.css
@@ -855,6 +855,9 @@ Table
     max-width: 320px;
 }
 
+.dataTables_wrapper {
+    overflow: auto;
+}
 /*.table>tbody>tr>td, */
 
 /*


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR is a temporary fix for issue #113. We have many datatables that have overflowing width across the site. Unfortunately, simply setting `scrollX: true` causes a host of other problems that will need more time to investigate. See #113 for more context.

As a temporary global fix, I've targeted the `dataTables_wrapper` element, and added scrolling behavior to it. This at least gives a stable scrolling implementation, although not ideal.

<!-- If there are relevant issues, link them here: -->
- Temporary fix (does not fully resolve) #113 

| Before | After |
| ------- | ------ |
| <img width="670" height="610" alt="image" src="https://github.com/user-attachments/assets/03212b46-b2ed-4e22-852e-9251f3464431" /> | <img width="668" height="631" alt="image" src="https://github.com/user-attachments/assets/d10b0089-4a24-46b0-81e9-a979b95de394" /> |

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
