### PR TITLE
styles: make download sections have consistent style

### DIFF
--- a/mason/breeders_toolbox/download.mas
+++ b/mason/breeders_toolbox/download.mas
@@ -7,16 +7,37 @@ $is_curator => 0
 
 <& /page/page_title.mas, title=>"Download Using Lists" &>
 
+<style>
+  /* Make table backgrounds and headers white, since nested in colored well */
+.table-download {
+  background-color: white;
+}
+.table-download thead {
+  background-color: white;
+}
+#phenotype_download_dataset_list thead {
+  background-color: white;
+}
+/* Allow text-wrapping in these tables for small scren sizes */
+#table_download_phenotypes tbody tr td,
+#table_download_pedigrees tbody tr td,
+#phenotype_download_dataset_list tbody tr td {
+  white-space: normal;
+}
+
+</style>
+
 <div class="container-fluid">
 
 <div class="well">
 Choose a list for each parameter and click "Download".
 </div>
 
-<div class="well well-sm">
-<h4>Download Phenotypes Using Lists</h4><p>Select Parameters:</p>
+<div class="well well-sm" style="margin-top: 20px">
+<&|  /page/info_section.mas, title => "<b>Download Phenotypes Using Lists</b>", collapsible => 1, collapsed => 1 &>
+<p>Select Parameters:</p>
 <form id="download_form" action="/breeders/download_action" method="POST" >
-<table class="table table-bordered" >
+<table class="table table-bordered table-download" id="table_download_phenotypes" >
   <thead>
   <tr>
     <th>
@@ -97,33 +118,22 @@ Choose a list for each parameter and click "Download".
   </tbody>
   </table>
 </form>
+</&>
 </div>
 
-<div class="well well-sm">
-<h4>Inspect Datasets</h4>
-<table class="table table-bordered" >
-  <thead>
-  <tr>
-    <th>
-      Datasets
-    </th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td>
+<div class="well well-sm" style="margin-top: 20px">
+  <&|  /page/info_section.mas, title => "<b>Inspect Datasets</b>", collapsible => 1, collapsed => 1 &>
       <div id="phenotype_download_dataset_list">
+        /* id="table_inspect_datasets" */
       </div>
-    </td>
-  </tr>
-  </tbody>
-  </table>
+  </&>
 </div>
 
-<div class="well well-sm">
-<h4>Download Metadata</h4><p>Select Parameters:</p>
+<div class="well well-sm" style="margin-top: 20px">
+<&|  /page/info_section.mas, title => "<b>Trial Metadata</b>", collapsible => 1, collapsed => 1 &>
+<p>Select Parameters:</p>
 <form id="download_metadata_form" action="/breeders/download_action" method="POST" >
-<table class="table table-bordered" >
+<table class="table table-bordered table-download">
   <thead>
   <tr>
     <th>
@@ -165,6 +175,7 @@ Choose a list for each parameter and click "Download".
   </tbody>
   </table>
 </form>
+</&>
 </div>
 
 <script>
@@ -277,11 +288,12 @@ function download_phenotypes() {
 
 <!-- DOWNLOAD ACCESSION PROPERTIES -->
 
-<div class="well well-sm">
+<div class="well well-sm" style="margin-top: 20px">
+  <&|  /page/info_section.mas, title => "<b>Accession Properties</b>", collapsible => 1, collapsed => 1 &>
+  <p>Select parameters:</p>
   <form id="download_accession_properties" action="/breeders/download_accession_properties_action" method="POST">
-    <table class="table"  cellpadding="10">
+    <table class="table table-download"  cellpadding="10">
       <thead>
-        <tr><td colspan="2"><h4>Download Accession Properties</h4><p>Select parameters:</p></tr>
         <tr>
           <th>Accessions</th>
           <th>Format</th>
@@ -307,6 +319,7 @@ function download_phenotypes() {
       </tbody>
   </table>
 </form>
+</&>
 </div>
 
 
@@ -358,11 +371,12 @@ $(document).ready(function() {
 
 <!-- start of code for pedigree download -->
 
-<div class="well well-sm">
+<div class="well well-sm" style="margin-top: 20px">
+<&|  /page/info_section.mas, title => "<b>Pedigrees</b>", collapsible => 1, collapsed => 1 &>
+<p>Select parameter:</p>
 <form id="download_pedigree" action="/breeders/download_pedigree_action" method="POST">
-<table class="table"  cellpadding="10">
+<table class="table table-download"  cellpadding="10" id="table_download_pedigrees">
   <thead>
-  <tr><td colspan="2"><h4>Download Pedigrees </h4><p>Select parameter:</p></tr>
   <tr>
     <th>
       Accessions
@@ -385,7 +399,7 @@ $(document).ready(function() {
       </div>
     </td>
     <td>
-      <div style="width: 175px">
+      <div>
         <p><strong>Depth:</strong></p>
         <div class="radio">
           <label><input type="radio" id="ped_format_parents" name="ped_format" value="parents_only" checked>Only One Generation</label>
@@ -418,6 +432,7 @@ $(document).ready(function() {
   </tbody>
   </table>
 </form>
+</&>
 </div>
 
 
@@ -456,11 +471,12 @@ $(document).ready(function() {
 
 <!-- start of code for cross and family download -->
 
-<div class="well well-sm">
+<div class="well well-sm" style="margin-top: 20px">
+<&|  /page/info_section.mas, title => "<b>Crosses and Families of Progenies</b>", collapsible => 1, collapsed => 1 &>
+<p>Select parameters:</p>
     <form id="download_cross_family" action="/breeders/download_cross_family_of_progenies" method="POST">
-        <table class="table"  cellpadding="10">
+        <table class="table table-download"  cellpadding="10">
             <thead>
-                <tr><td colspan="2"><h4>Download Crosses and Families of Progenies </h4><p>Select parameters:</p></tr>
                 <tr>
                     <th>Accessions</th>
                     <th>Format</th>
@@ -486,6 +502,7 @@ $(document).ready(function() {
             </tbody>
         </table>
     </form>
+</&>
 </div>
 
 
@@ -520,11 +537,13 @@ $(document).ready(function() {
 
 <!-- start of code for seedlot details download -->
 
-<div class="well well-sm">
+<div class="well well-sm" style="margin-top: 20px">
+    <&|  /page/info_section.mas, title => "<b>Seedlot Details</b>", collapsible => 1, collapsed => 1 &>
+    <p>Select parameters:</p>
+
     <form id="download_seedlot_details" action="/list/download_details" method="POST">
-        <table class="table"  cellpadding="10">
+        <table class="table table-download"  cellpadding="10">
             <thead>
-                <tr><td colspan="2"><h4>Download Seedlot Details </h4><p>Select parameters:</p></tr>
                 <tr>
                     <th>Seedlots</th>
                     <th>Format</th>
@@ -550,6 +569,7 @@ $(document).ready(function() {
             </tbody>
         </table>
     </form>
+    </&>
 </div>
 
 
@@ -587,11 +607,12 @@ $(document).ready(function() {
 
 % if ( $seedlot_maintenance_enabled ) {
 
-<div class="well well-sm">
+<div class="well well-sm" style="margin-top: 20px">
+  <&|  /page/info_section.mas, title => "<b>Seedlot Maintenance Events</b>", collapsible => 1, collapsed => 1 &>
+  <p>Select parameters:</p>
   <form id="download_seedlot_maintenance_events" action="/breeders/download_seedlot_maintenance_events_action" method="POST">
-      <table class="table"  cellpadding="10">
+      <table class="table table-download"  cellpadding="10">
         <thead>
-          <tr><td colspan="2"><h4>Download Seedlot Maintenance Events</h4><p>Select parameters:</p></tr>
           <tr>
             <th>Seedlots</th>
             <th>Format</th>
@@ -616,6 +637,7 @@ $(document).ready(function() {
         </tbody>
     </table>
   </form>
+  </&>
 </div>
 
 <script>
@@ -664,11 +686,12 @@ $(document).ready(function() {
 
 % if ($is_curator) {
 
-<div class="well well-sm">
+<div class="well well-sm" style="margin-top: 20px">
+    <&|  /page/info_section.mas, title => "<b>Obsolete Metadata</b>", collapsible => 1, collapsed => 1 &>
+    <p>Select parameters:</p>
     <form id="download_obsolete_metadata_action" action="/breeders/download_obsolete_metadata_action" method="POST">
-        <table class="table" cellpadding="10">
+        <table class="table table-download" cellpadding="10">
             <thead>
-                <tr><td colspan="2"><h4>Download Obsolete Metadata</h4><p>Select parameters:</p></tr>
                 <tr>
                     <th>Obsoleted Stocks</th>
                     <th>Format</th>
@@ -693,6 +716,7 @@ $(document).ready(function() {
             </tbody>
         </table>
     </form>
+    </&>
 </div>
 
 <script>
@@ -728,11 +752,12 @@ jQuery(document).ready(function() {
 <!-- end of code for obsolete metadata download -->
 
 
-<div class="well well-sm">
+<div class="well well-sm" style="margin-top: 20px">
+<&|  /page/info_section.mas, title => "<b>Genotypes</b>", collapsible => 1, collapsed => 1 &>
+<p>Select parameter:</p>
 <form id="download_gbs" action="/breeders/download_gbs_action" method="POST">
-<table class="table"  cellpadding="10">
+<table class="table table-download"  cellpadding="10">
   <thead>
-  <tr><td colspan="2"><h4>Download Genotypes </h4><p>Select parameter:</p></tr>
   <tr>
     <th>
       Accessions
@@ -763,6 +788,7 @@ jQuery(document).ready(function() {
   </tbody>
   </table>
 </form>
+</&>
 </div>
 
 <script>
@@ -805,11 +831,12 @@ jQuery(document).ready(function() {
   });
 </script>
 
-<div class="well well-sm">
+<div class="well well-sm" style="margin-top: 20px">
+<&|  /page/info_section.mas, title => "<b>Genotyping QC</b>", collapsible => 1, collapsed => 1 &>
+<p>Select parameter:</p>
 <form id="gbs_qc" action="/breeders/gbs_qc_action" method="POST">
 <table class="table" cellpadding="10">
   <thead>
-  <tr><td colspan="3"><h4>Genotyping QC</h4><p>Select parameter:</p></tr>
   <tr>
     <th>
       Trials
@@ -848,7 +875,7 @@ jQuery(document).ready(function() {
   </table>
 </form>
 </div>
-
+</&>
 </div>
 
 <script>

--- a/mason/breeders_toolbox/download.mas
+++ b/mason/breeders_toolbox/download.mas
@@ -34,7 +34,7 @@ Choose a list for each parameter and click "Download".
 </div>
 
 <div class="well well-sm" style="margin-top: 20px">
-<&|  /page/info_section.mas, title => "<b>Download Phenotypes Using Lists</b>", collapsible => 1, collapsed => 1 &>
+<&|  /page/info_section.mas, title => "<b>Download Phenotypes Using Lists</b>", id => "download_phenotypes", collapsible => 1, collapsed => 1 &>
 <p>Select Parameters:</p>
 <form id="download_form" action="/breeders/download_action" method="POST" >
 <table class="table table-bordered table-download" id="table_download_phenotypes" >
@@ -122,7 +122,7 @@ Choose a list for each parameter and click "Download".
 </div>
 
 <div class="well well-sm" style="margin-top: 20px">
-  <&|  /page/info_section.mas, title => "<b>Inspect Datasets</b>", collapsible => 1, collapsed => 1 &>
+  <&|  /page/info_section.mas, title => "<b>Inspect Datasets</b>", id => "inspect_datasets", collapsible => 1, collapsed => 1 &>
       <div id="phenotype_download_dataset_list">
         /* id="table_inspect_datasets" */
       </div>
@@ -130,7 +130,7 @@ Choose a list for each parameter and click "Download".
 </div>
 
 <div class="well well-sm" style="margin-top: 20px">
-<&|  /page/info_section.mas, title => "<b>Trial Metadata</b>", collapsible => 1, collapsed => 1 &>
+<&|  /page/info_section.mas, title => "<b>Trial Metadata</b>", id => "download_trial_metadata", collapsible => 1, collapsed => 1 &>
 <p>Select Parameters:</p>
 <form id="download_metadata_form" action="/breeders/download_action" method="POST" >
 <table class="table table-bordered table-download">
@@ -289,7 +289,7 @@ function download_phenotypes() {
 <!-- DOWNLOAD ACCESSION PROPERTIES -->
 
 <div class="well well-sm" style="margin-top: 20px">
-  <&|  /page/info_section.mas, title => "<b>Accession Properties</b>", collapsible => 1, collapsed => 1 &>
+  <&|  /page/info_section.mas, title => "<b>Accession Properties</b>", id => "download_accession_properties", collapsible => 1, collapsed => 1 &>
   <p>Select parameters:</p>
   <form id="download_accession_properties" action="/breeders/download_accession_properties_action" method="POST">
     <table class="table table-download"  cellpadding="10">
@@ -372,7 +372,7 @@ $(document).ready(function() {
 <!-- start of code for pedigree download -->
 
 <div class="well well-sm" style="margin-top: 20px">
-<&|  /page/info_section.mas, title => "<b>Pedigrees</b>", collapsible => 1, collapsed => 1 &>
+<&|  /page/info_section.mas, title => "<b>Pedigrees</b>", id => "download_pedigrees", collapsible => 1, collapsed => 1 &>
 <p>Select parameter:</p>
 <form id="download_pedigree" action="/breeders/download_pedigree_action" method="POST">
 <table class="table table-download"  cellpadding="10" id="table_download_pedigrees">
@@ -472,7 +472,7 @@ $(document).ready(function() {
 <!-- start of code for cross and family download -->
 
 <div class="well well-sm" style="margin-top: 20px">
-<&|  /page/info_section.mas, title => "<b>Crosses and Families of Progenies</b>", collapsible => 1, collapsed => 1 &>
+<&|  /page/info_section.mas, title => "<b>Crosses and Families of Progenies</b>", id => "download_crosses_families_of_progenies", collapsible => 1, collapsed => 1 &>
 <p>Select parameters:</p>
     <form id="download_cross_family" action="/breeders/download_cross_family_of_progenies" method="POST">
         <table class="table table-download"  cellpadding="10">
@@ -538,7 +538,7 @@ $(document).ready(function() {
 <!-- start of code for seedlot details download -->
 
 <div class="well well-sm" style="margin-top: 20px">
-    <&|  /page/info_section.mas, title => "<b>Seedlot Details</b>", collapsible => 1, collapsed => 1 &>
+    <&|  /page/info_section.mas, title => "<b>Seedlot Details</b>", id => "download_seedlot_details", collapsible => 1, collapsed => 1 &>
     <p>Select parameters:</p>
 
     <form id="download_seedlot_details" action="/list/download_details" method="POST">
@@ -608,7 +608,7 @@ $(document).ready(function() {
 % if ( $seedlot_maintenance_enabled ) {
 
 <div class="well well-sm" style="margin-top: 20px">
-  <&|  /page/info_section.mas, title => "<b>Seedlot Maintenance Events</b>", collapsible => 1, collapsed => 1 &>
+  <&|  /page/info_section.mas, title => "<b>Seedlot Maintenance Events</b>", id => "download_seedlot_maintenance_events", collapsible => 1, collapsed => 1 &>
   <p>Select parameters:</p>
   <form id="download_seedlot_maintenance_events" action="/breeders/download_seedlot_maintenance_events_action" method="POST">
       <table class="table table-download"  cellpadding="10">
@@ -687,7 +687,7 @@ $(document).ready(function() {
 % if ($is_curator) {
 
 <div class="well well-sm" style="margin-top: 20px">
-    <&|  /page/info_section.mas, title => "<b>Obsolete Metadata</b>", collapsible => 1, collapsed => 1 &>
+    <&|  /page/info_section.mas, title => "<b>Obsolete Metadata</b>", id => "download_obsolete_metadata", collapsible => 1, collapsed => 1 &>
     <p>Select parameters:</p>
     <form id="download_obsolete_metadata_action" action="/breeders/download_obsolete_metadata_action" method="POST">
         <table class="table table-download" cellpadding="10">
@@ -753,7 +753,7 @@ jQuery(document).ready(function() {
 
 
 <div class="well well-sm" style="margin-top: 20px">
-<&|  /page/info_section.mas, title => "<b>Genotypes</b>", collapsible => 1, collapsed => 1 &>
+<&|  /page/info_section.mas, title => "<b>Genotypes</b>", id => "download_genotypes", collapsible => 1, collapsed => 1 &>
 <p>Select parameter:</p>
 <form id="download_gbs" action="/breeders/download_gbs_action" method="POST">
 <table class="table table-download"  cellpadding="10">
@@ -832,7 +832,7 @@ jQuery(document).ready(function() {
 </script>
 
 <div class="well well-sm" style="margin-top: 20px">
-<&|  /page/info_section.mas, title => "<b>Genotyping QC</b>", collapsible => 1, collapsed => 1 &>
+<&|  /page/info_section.mas, title => "<b>Genotyping QC</b>", id => "download_genotyping_qc", collapsible => 1, collapsed => 1 &>
 <p>Select parameter:</p>
 <form id="gbs_qc" action="/breeders/gbs_qc_action" method="POST">
 <table class="table" cellpadding="10">

--- a/mason/breeders_toolbox/download.mas
+++ b/mason/breeders_toolbox/download.mas
@@ -33,7 +33,7 @@ $is_curator => 0
 Choose a list for each parameter and click "Download".
 </div>
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
 <&|  /page/info_section.mas, title => "<b>Download Phenotypes Using Lists</b>", id => "download_phenotypes", collapsible => 1, collapsed => 1 &>
 <p>Select Parameters:</p>
 <form id="download_form" action="/breeders/download_action" method="POST" >
@@ -121,7 +121,7 @@ Choose a list for each parameter and click "Download".
 </&>
 </div>
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
   <&|  /page/info_section.mas, title => "<b>Inspect Datasets</b>", id => "inspect_datasets", collapsible => 1, collapsed => 1 &>
       <div id="phenotype_download_dataset_list">
         /* id="table_inspect_datasets" */
@@ -129,7 +129,7 @@ Choose a list for each parameter and click "Download".
   </&>
 </div>
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
 <&|  /page/info_section.mas, title => "<b>Trial Metadata</b>", id => "download_trial_metadata", collapsible => 1, collapsed => 1 &>
 <p>Select Parameters:</p>
 <form id="download_metadata_form" action="/breeders/download_action" method="POST" >
@@ -288,7 +288,7 @@ function download_phenotypes() {
 
 <!-- DOWNLOAD ACCESSION PROPERTIES -->
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
   <&|  /page/info_section.mas, title => "<b>Accession Properties</b>", id => "download_accession_properties", collapsible => 1, collapsed => 1 &>
   <p>Select parameters:</p>
   <form id="download_accession_properties" action="/breeders/download_accession_properties_action" method="POST">
@@ -371,7 +371,7 @@ $(document).ready(function() {
 
 <!-- start of code for pedigree download -->
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
 <&|  /page/info_section.mas, title => "<b>Pedigrees</b>", id => "download_pedigrees", collapsible => 1, collapsed => 1 &>
 <p>Select parameter:</p>
 <form id="download_pedigree" action="/breeders/download_pedigree_action" method="POST">
@@ -471,7 +471,7 @@ $(document).ready(function() {
 
 <!-- start of code for cross and family download -->
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
 <&|  /page/info_section.mas, title => "<b>Crosses and Families of Progenies</b>", id => "download_crosses_families_of_progenies", collapsible => 1, collapsed => 1 &>
 <p>Select parameters:</p>
     <form id="download_cross_family" action="/breeders/download_cross_family_of_progenies" method="POST">
@@ -537,7 +537,7 @@ $(document).ready(function() {
 
 <!-- start of code for seedlot details download -->
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
     <&|  /page/info_section.mas, title => "<b>Seedlot Details</b>", id => "download_seedlot_details", collapsible => 1, collapsed => 1 &>
     <p>Select parameters:</p>
 
@@ -607,7 +607,7 @@ $(document).ready(function() {
 
 % if ( $seedlot_maintenance_enabled ) {
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
   <&|  /page/info_section.mas, title => "<b>Seedlot Maintenance Events</b>", id => "download_seedlot_maintenance_events", collapsible => 1, collapsed => 1 &>
   <p>Select parameters:</p>
   <form id="download_seedlot_maintenance_events" action="/breeders/download_seedlot_maintenance_events_action" method="POST">
@@ -686,7 +686,7 @@ $(document).ready(function() {
 
 % if ($is_curator) {
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
     <&|  /page/info_section.mas, title => "<b>Obsolete Metadata</b>", id => "download_obsolete_metadata", collapsible => 1, collapsed => 1 &>
     <p>Select parameters:</p>
     <form id="download_obsolete_metadata_action" action="/breeders/download_obsolete_metadata_action" method="POST">
@@ -752,7 +752,7 @@ jQuery(document).ready(function() {
 <!-- end of code for obsolete metadata download -->
 
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
 <&|  /page/info_section.mas, title => "<b>Genotypes</b>", id => "download_genotypes", collapsible => 1, collapsed => 1 &>
 <p>Select parameter:</p>
 <form id="download_gbs" action="/breeders/download_gbs_action" method="POST">
@@ -831,7 +831,7 @@ jQuery(document).ready(function() {
   });
 </script>
 
-<div class="well well-sm" style="margin-top: 20px">
+<div class="well well-sm tw:mt-8!">
 <&|  /page/info_section.mas, title => "<b>Genotyping QC</b>", id => "download_genotyping_qc", collapsible => 1, collapsed => 1 &>
 <p>Select parameter:</p>
 <form id="gbs_qc" action="/breeders/gbs_qc_action" method="POST">

--- a/t/selenium2/breeders/pedigree_download.t
+++ b/t/selenium2/breeders/pedigree_download.t
@@ -5,10 +5,21 @@ use Test::More;
 use SGN::Test::WWW::WebDriver;
 use SGN::Test::Fixture;
 use Selenium::Remote::WDKeys 'KEYS';
+use Selenium::Firefox::Profile;
 
 my $f = SGN::Test::Fixture->new();
 
 my $t = SGN::Test::WWW::WebDriver->new();
+
+# Create firefox profile for download options
+my $profile = Selenium::Firefox::Profile->new;
+$profile->set_preference( 'browser.download.folderList', 2 ); # Use custom download folder
+$profile->set_preference( 'browser.download.dir', '/downloads' ); # Path to custom download folder on selenium host
+$profile->set_preference( 'browser.helperApps.neverAsk.saveToDisk', 'plain/text', 'application/text' ); # Automatically download to disk
+
+# Create web driver
+my $driver = Selenium::Remote::Driver->new(firefox_profile => $profile, base_url => $ENV{SGN_TEST_SERVER}, remote_server_addr => $ENV{SGN_REMOTE_SERVER_ADDR} || 'localhost');
+$t->driver($driver);
 
 $t->while_logged_in_as("submitter", sub {
     $t->get_ok('/breeders/accessions');
@@ -86,6 +97,7 @@ $t->while_logged_in_as("submitter", sub {
     $t->get_ok('/breeders/download');
     sleep(3); # FIXME Need to wait for page to settle / elements to register
 
+    $t->click_ok("download_pedigrees_onswitch", "id", "open download pedigrees section");
     $t->click_ok("pedigree_accession_list_list_select", "id", "select pedigrees accession download list");
 
     $t->click_ok(


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR cleans up the styling in the Download page (`Manage` -> `Download`) to achieve the following.

- Makes each section a collapsible accordion, so that it's not so visually overwhelming when first opening the page.
- Increases the vertical margins between wells so the spacing is not so tight.
- Makes all the wells and tables have consistent styling, such as ensuring all table backgrounds are white.
- Allows word wrapping within tables with very wide content, to accomodate small screen sizes.

<!-- If there are relevant issues, link them here: -->
- Resolves #98 

| Before | After |
| ------- | ------ |
| <img width="780" alt="image" src="https://github.com/user-attachments/assets/4203ca47-b90b-4ce0-8ad7-c3673faa02ca" /> | <img width="780"  alt="image" src="https://github.com/user-attachments/assets/c891d34c-0809-4dd2-a16e-26290e346e13" /> |

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
