### PR TITLE
trial: exclude Filler accessions from stock count

### DIFF
--- a/lib/CXGN/Project.pm
+++ b/lib/CXGN/Project.pm
@@ -5084,12 +5084,18 @@ sub get_accessions {
 =cut
 
 sub get_trial_stock_count {
-	my $self = shift;
+    my $self = shift;
 
-	my $accessions = $self->get_accessions();
-	my $stock_count = scalar(@{$accessions});
+    my $accessions = $self->get_accessions();
+    my @accessions_no_filler;
+    while (my ($i, $el) = each @{$accessions}) {
+        if ($el->{accession_name} ne 'Filler'){
+            push(@accessions_no_filler, $el);
+        }
+    }
+    my $stock_count = scalar(@accessions_no_filler);
 
-	return $stock_count;
+    return $stock_count;
 }
 
 =head2 get_tissue_sources


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR excludes "Filler" accessions from the count of stocks planted in a trial. It's helpful to exclude them because Fillers (ie. non-experimental trees or empty plots) are not typically included

<!-- If there are relevant issues, link them here: -->
- Resolves #85 

In the following trial, there is 1 accession planted in replicate, and the "Filler" accession is used to mark empty plots. With this change, the trial details page correctly says 1 stock is planted.
<img width="480" alt="image" src="https://github.com/user-attachments/assets/be906e75-19d9-4b20-849b-818ff01dbd2a" />

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
