### PR TITLE
search: fix broken stock properties search

### DIFF
--- a/db/00205.1/CreateStockPropsView.pm
+++ b/db/00205.1/CreateStockPropsView.pm
@@ -1,0 +1,67 @@
+#!/usr/bin/env perl
+
+=head1 NAME
+
+CreateStockPropsView.pm
+
+=head1 SYNOPSIS
+
+mx-run CreateStockPropsView [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+This patch:
+ - Creates a new view stockprops, that aggregates stockprops for a stock into
+   one column.
+
+=head1 AUTHOR
+
+Katherine Eaton
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2026 University of Alberta
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+package CreateStockPropsView;
+
+use Moose;
+use Bio::Chado::Schema;
+extends 'CXGN::Metadata::Dbpatch';
+
+has '+description' => ( default => <<'' );
+This patch creates a new view stockprops, that aggregates stockprops for a stock into one column.
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    $self->dbh->do(<<EOSQL);
+create view public.stockprops as (
+    select stock_id, jsonb_object_agg(cvterm.name, stockprop.value) as stockprops
+    from stockprop
+    join cvterm on (type_id = cvterm_id) and cv_id = (select cv_id from cv where cv.name = 'stock_property')
+    group by stock_id
+);
+alter view public.stockprops owner to web_usr;
+
+EOSQL
+
+    print "You're done!\n";
+}
+
+####
+1; #
+####

--- a/lib/CXGN/Stock/Search.pm
+++ b/lib/CXGN/Stock/Search.pm
@@ -463,14 +463,9 @@ sub search {
 
         my $index=0;
         foreach my $term_name (keys %{$self->stockprops_values}){
-            my $property_term = SGN::Model::Cvterm->get_cvterm_row($schema, $term_name, 'stock_property');
-            if ($property_term){
                 $index++;
-                my $type_id = $property_term->cvterm_id();
                 my $matchtype = $self->stockprops_values->{$term_name}->{'matchtype'};
                 my $value = $self->stockprops_values->{$term_name}->{'value'};
-
-		#push @stockprop_joins, "LEFT JOIN public.stockprop AS sp$index ON (stock.stock_id = sp$index.stock_id) AND sp$index.type_id = $type_id";
 
                 my $start = '%';
                 my $end = '%';
@@ -492,24 +487,20 @@ sub search {
                     s{^\s+|\s+$}{}g foreach @values;
                     #my $search_vals_sql = "'".join ("','" , @values)."'";
                     #push @stockprop_wheres, "sp$index.value IN ($search_vals_sql)";
-		    push @stockprop_wheres, " (type_id = $type_id and value in (" . join(" ", '?' x scalar(@values) ).") ) ";
+		    push @stockprop_wheres, " (stockprops->>'$term_name' value in (" . join(" ", '?' x scalar(@values) ).") ) ";
 		    @placeholder_values = (@placeholder_values, @values);
 
                 } else {
 		    #print STDERR "START $start end $end SEARCH $value\n";
                     #push @stockprop_wheres, "sp$index.value ilike $search";
 
-		    push @stockprop_wheres, " (type_id = $type_id and value ilike ? ) ";
+		    push @stockprop_wheres, " (stockprops->>'$term_name' ilike ? ) ";
 		    push @placeholder_values, $start.$value.$end;
                 }
-
-            } else {
-                print STDERR "Stockprop $term_name is not in this database! Only use stock_property in system_cvterms.txt!\n";
-            }
         }
         #my $stockprop_join = join ' ', @stockprop_joins;
         my $stockprop_where = 'WHERE ' . join ' AND ', @stockprop_wheres;
-        my $stockprop_query = "SELECT stockprop.stock_id FROM public.stockprop $stockprop_where;";
+        my $stockprop_query = "SELECT stockprops.stock_id FROM public.stockprops $stockprop_where;";
 
 	print STDERR "STOCKPROP QUERY: $stockprop_query with placeholders ".join(", ", @placeholder_values)."\n";
         my $h = $schema->storage->dbh()->prepare($stockprop_query);

--- a/lib/CXGN/Stock/Search.pm
+++ b/lib/CXGN/Stock/Search.pm
@@ -487,7 +487,7 @@ sub search {
                     s{^\s+|\s+$}{}g foreach @values;
                     #my $search_vals_sql = "'".join ("','" , @values)."'";
                     #push @stockprop_wheres, "sp$index.value IN ($search_vals_sql)";
-		    push @stockprop_wheres, " (stockprops->>'$term_name' value in (" . join(" ", '?' x scalar(@values) ).") ) ";
+		    push @stockprop_wheres, " (stockprops->>'$term_name' in (" . join(",", ('?') x scalar(@values) ).") ) ";
 		    @placeholder_values = (@placeholder_values, @values);
 
                 } else {

--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -426,7 +426,14 @@ jQuery(document).ready(function () {
     jQuery('#editable_stockprop_search_add').click( function(){
         // console.log("editable stockprops search is "+JSON.stringify(editable_stockprops_search));
         // console.log("Value is "+jQuery('#editable_stockprop_search_term').val());
-        editable_stockprops_search[jQuery('#editable_stockprop_search_term').val()] = {"matchtype": "contains"};
+        const selected_property = jQuery('#editable_stockprop_search_term').val();
+        const value = jQuery('#editable_stockprop_search_term').val();
+        if (!(selected_property in stockprop_extra_columns_view)){
+            stockprop_extra_columns_view[selected_property] = 1;
+            stockprop_extra_columns_view_array.push(selected_property);
+            updateResultsHeader();
+        }
+        editable_stockprops_search[value] = {"matchtype": "contains"};
         console.log("editable stockprops search is "+JSON.stringify(editable_stockprops_search));
         _draw_editable_stockprops_search_fields();
     });
@@ -508,21 +515,15 @@ jQuery(document).ready(function () {
     let stockprop_extra_columns_view_array = [ 'organization' ];
 
     function updateResultsHeader() {
-        let table_header_html =
-          '<table id="stock_search_results" class="table table-hover table-striped" width="100%">' +
-            '<thead><tr>' +
-              '<th>Stock Id</th>' +
-              '<th>Stock Name</th>' +
-              '<th>Stock Type</th>' +
-              '<th>Organism</th>' +
-              '<th>Synonyms</th>';
-        for (let i = 0; i < stockprop_extra_columns_view_array.length; i++) {
-          table_header_html += '<th>' + stockprop_extra_columns_view_array[i] + '</th>';
-        }
-        table_header_html +=
-            '</tr></thead>' +
-          '</table>';
-        jQuery('#stock_search_results_div').html(table_header_html);
+      let table_colnames = ["Stock Id", "Stock Name", "Stock Type", "Organism", "Synonyms"];
+      for (let i = 0; i < stockprop_extra_columns_view_array.length; i++) {
+        table_colnames.push(stockprop_extra_columns_view_array[i]);
+      }
+
+      let table_header_html = '<table id="stock_search_results" class="table table-hover table-striped" width="100%"><thead><tr>';
+      table_colnames.forEach(function(col) { table_header_html += `<th>${col}</th>` });
+      table_header_html += '</tr></thead></table>';
+      jQuery('#stock_search_results_div').html(table_header_html);
     }
 
     function updateResultsRows() {
@@ -535,8 +536,8 @@ jQuery(document).ready(function () {
         if (!(selected_property in stockprop_extra_columns_view)){
             stockprop_extra_columns_view[selected_property] = 1;
             stockprop_extra_columns_view_array.push(selected_property);
-            updateResultsHeader();
         }
+        updateResultsHeader();
         updateResultsRows();
     });
     jQuery('#editable_stockprop_view_column_remove').click(function(){
@@ -546,9 +547,9 @@ jQuery(document).ready(function () {
           const selected_index = stockprop_extra_columns_view_array.indexOf(selected_property);
           if (selected_index !== -1) {
             stockprop_extra_columns_view_array.splice(selected_index, 1);
-            updateResultsHeader();
           }
         }
+        updateResultsHeader();
         updateResultsRows();
     })
 
@@ -747,6 +748,7 @@ function _load_stock_search_results(stock_type, editable_stockprops_search, stoc
 
     var export_message = 'Stock data from ' + window.location.href;
     var export_suffix = ' Stocks';
+
     stock_table = jQuery('#stock_search_results').DataTable({
         'destroy' : true,
         'searching' : false,

--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -515,7 +515,7 @@ jQuery(document).ready(function () {
     let stockprop_extra_columns_view_array = [ 'organization' ];
 
     function updateResultsHeader() {
-      let table_colnames = ["Stock Id", "Stock Name", "Stock Type", "Organism", "Synonyms"];
+      const table_colnames = ["Stock Id", "Stock Name", "Stock Type", "Organism", "Synonyms"];
       for (let i = 0; i < stockprop_extra_columns_view_array.length; i++) {
         table_colnames.push(stockprop_extra_columns_view_array[i]);
       }

--- a/t/lib/SGN/Test/WWW/WebDriver.pm
+++ b/t/lib/SGN/Test/WWW/WebDriver.pm
@@ -188,6 +188,27 @@ sub click_ok {
     return $element;
 }
 
+sub clear {
+    my $self = shift;
+    my $name = shift;
+    my $method = shift;
+
+    my $timeout = $self->driver->get_timeouts()->{"implicit"} / 1000; # in seconds
+    return wait_until {
+        $self->screenshot("clear_$name");
+        $self->driver->find_element($name, $method)->clear();
+    } timeout => $timeout;
+}
+
+sub clear_ok {
+    my $self = shift;
+    my $name = shift;
+    my $method = shift;
+    my $test_name = shift || print STDERR "You can provide a test name parameter for clear_ok\n";
+    ok(my $element = $self->clear($name, $method), $test_name);
+    return $element;
+}
+
 =item click_until_ok($self, $name_btn, $method_btn, $name_sentinel, $method_sentinel, $test_name)
 Keeps clicking the button defined by $name_btn and $method_btn every second
 until the sentinel element defined by $name_sentinel and $method_sentinel appears.

--- a/t/selenium2/search/stock.t
+++ b/t/selenium2/search/stock.t
@@ -5,25 +5,108 @@ use lib 't/lib';
 
 use Test::More;
 use SGN::Test::WWW::WebDriver;
+use SGN::Test::Fixture;
+use SGN::Model::Cvterm;
 
 my $d = SGN::Test::WWW::WebDriver->new();
+$d->driver->set_timeout('implicit', 5000);
 
-$d->get_ok('/search/stocks');
-my $page_source = lc($d->driver()->get_page_source());
+# Set up the DB connection
+my $f = SGN::Test::Fixture->new();
+my $schema = $f->bcs_schema;
 
-ok($page_source =~ /search accessions/, "Search page title presence");
+# -------------------------------------------------------------------------
+# Data Setup
 
-ok($page_source =~ /project location/, "Search options present");
+# Create some stock properties for us to search for ('country of origin', 'state')
+my $test_accession1_stock_id = $schema->resultset("Stock::Stock")->find({uniquename => "test_accession1"})->stock_id();
+my $test_accession2_stock_id = $schema->resultset("Stock::Stock")->find({uniquename => "test_accession2"})->stock_id();
 
-sleep(2);
+my $country_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, "country of origin", "stock_property")->cvterm_id();
+my $state_cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, "state", "stock_property")->cvterm_id();
 
-$d->find_element_ok("any_name", "id", "find any_name html input element")->send_keys("test_accession1");
+my $test_accession1_country = $schema->resultset("Stock::Stockprop")->find_or_create({stock_id => $test_accession1_stock_id, type_id => $country_cvterm, value => 'test_country_1'});
+my $test_accession2_country = $schema->resultset("Stock::Stockprop")->find_or_create({stock_id => $test_accession2_stock_id, type_id => $country_cvterm, value => 'test_country_2'});
+my $test_accession1_state = $schema->resultset("Stock::Stockprop")->find_or_create({stock_id => $test_accession1_stock_id, type_id => $state_cvterm, value => 'test_state_1'});
+my $test_accession2_state = $schema->resultset("Stock::Stockprop")->find_or_create({stock_id => $test_accession2_stock_id, type_id => $state_cvterm, value => 'test_state_2'});
 
-$d->find_element("//select[\@id=\"stock_type_select\"]/option[text()='accession']", "xpath","select stock type")->click();
+$d->while_logged_in_as("user", sub {
 
-$d->find_element_ok("submit_stock_search", "id", "submit search")->click();
-sleep(5);
-$d->find_element_ok("test_accession1", "partial_link_text", "verify search")->click();
+    # -------------------------------------------------------------------------
+    # Simple Search
 
+    $d->get_ok('/search/stocks');
+    my $page_source = lc($d->driver()->get_page_source());
+
+    ok($page_source =~ /search accessions/, "Search page title presence");
+
+    ok($page_source =~ /project location/, "Search options present");
+
+    $d->send_keys_ok("any_name", "id", "test_accession1", "find any_name html input element");
+
+    $d->click_ok("//select[\@id=\"stock_type_select\"]/option[text()='accession']", "xpath","select stock type");
+
+    $d->click_ok("submit_stock_search", "id", "submit search");
+    $d->click_ok("test_accession1", "partial_link_text", "verify search");
+
+    $d->find_element_ok("Solanum lycopersicum", "link_text", "verify organism");
+    $d->wait_for_network_idle();
+
+    # -------------------------------------------------------------------------
+    # Search by Stock Properties
+
+    $d->get_ok('/search/stocks');
+    $d->click_ok("advanced_search_panel_onswitch", "id", "open advanced search");
+    $d->click_ok("stock_search_properties_panel_onswitch", "id", "open properties search");
+
+    my $search_results;
+
+    # Search for single property ('test_state_1') that only matches only 1 accession
+    $d->click_ok("//select[\@id=\"editable_stockprop_search_term\"]/option[text()='state']", "xpath","select state property");
+    $d->click_ok("editable_stockprop_search_add", "id", "add state property");
+    $d->send_keys_ok("state_input_id", "id", "test_state_1", "enter state property");
+    $d->click_ok("submit_stock_search", "id", "submit search");
+    $search_results = $d->get_attribute_ok("stock_search_results", "id", "innerHTML", "get search results content");
+    ok($search_results =~ /test_accession1/, "verify test_accession1 is in results");
+    ok($search_results !~ /test_accession2/, "verify test_accession2 is not in results");
+
+    # Search for single property ('test_state') that only matches 2 accessions
+    $d->clear_ok("state_input_id", "id", "clear state property");
+    $d->send_keys_ok("state_input_id", "id", "test_state", "enter state property");
+    $d->click_ok("submit_stock_search", "id", "submit search");
+    $search_results = $d->get_attribute_ok("stock_search_results", "id", "innerHTML", "get search results content");
+    ok($search_results =~ /test_accession1/, "verify test_accession1 is in results");
+    ok($search_results =~ /test_accession2/, "verify test_accession2 is in results");
+
+    # Search for multiple properties (state, country of origin ) that only matches 1 accession
+    $d->clear_ok("state_input_id", "id", "clear state property");
+    $d->send_keys_ok("state_input_id", "id", "test_state_1", "enter state property");
+    $d->click_ok("//select[\@id=\"editable_stockprop_search_term\"]/option[text()='country of origin']", "xpath","select country property");
+    $d->click_ok("editable_stockprop_search_add", "id", "add country property");
+    $d->send_keys_ok("country_of_origin_input_id", "id", "test_country_1", "enter country property");
+    $d->click_ok("submit_stock_search", "id", "submit search");
+    $search_results = $d->get_attribute_ok("stock_search_results", "id", "innerHTML", "get search results content");
+    ok($search_results =~ /test_accession1/, "verify test_accession1 is in results");
+    ok($search_results !~ /test_accession2/, "verify test_accession2 is not in results");
+
+    # Search for multiple properties (state, country of origin ) that only matches 2 accessions
+    $d->clear_ok("state_input_id", "id", "clear state property");
+    $d->send_keys_ok("state_input_id", "id", "test_state", "enter state property");
+    $d->clear_ok("country_of_origin_input_id", "id", "clear country property");
+    $d->send_keys_ok("country_of_origin_input_id", "id", "test_country", "enter country property");
+    $d->click_ok("submit_stock_search", "id", "submit search");
+    $search_results = $d->get_attribute_ok("stock_search_results", "id", "innerHTML", "get search results content");
+    ok($search_results =~ /test_accession1/, "verify test_accession1 is in results");
+    ok($search_results =~ /test_accession2/, "verify test_accession2 is in results");
+
+});
+
+# Cleanup
+$test_accession1_country->delete() if defined $test_accession1_country;
+$test_accession2_country->delete() if defined $test_accession2_country;
+$test_accession1_state->delete() if defined $test_accession1_state;
+$test_accession2_state->delete() if defined $test_accession2_state;
+
+$d->wait_for_network_idle();
 $d->driver->quit();
 done_testing();

--- a/t/selenium2/search/stock.t
+++ b/t/selenium2/search/stock.t
@@ -99,6 +99,18 @@ $d->while_logged_in_as("user", sub {
     ok($search_results =~ /test_accession1/, "verify test_accession1 is in results");
     ok($search_results =~ /test_accession2/, "verify test_accession2 is in results");
 
+    # Search for one of
+    $d->click_ok("reset_stock_search", "id", "reset search");
+    $d->click_ok("//select[\@id=\"editable_stockprop_search_term\"]/option[text()='state']", "xpath","select state property");
+    $d->click_ok("editable_stockprop_search_add", "id", "add state property");
+    $d->click_ok("//select[\@id=\"editable_stockprop_matchtype\"]/option[\@value='one of']", "xpath","select one of match type");
+    $d->send_keys_ok("state_input_id", "id", "test_state_1,test_state_2", "enter state properties");
+    $d->click_ok("submit_stock_search", "id", "submit search");
+    $search_results = $d->get_attribute_ok("stock_search_results", "id", "innerHTML", "get search results content");
+    ok($search_results =~ /test_accession1/, "verify test_accession1 is in results");
+    ok($search_results =~ /test_accession2/, "verify test_accession2 is in results");
+
+
 });
 
 # Cleanup


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR fixes an upstream bug that broke the ability to search for stocks using multiple properties.

- Resolves #131

The original (working) logic used a MATERIALIZED VIEW called `materialized_stockprop` which has since been deprecated. This was a wide table that mapped a stock id to various different stockprops, which were manually defined to be separate columns. However, the system now allows us to dynamically create custom stockprops using the config `editable_stockprops`, which would be missing from this materialized view. That's likely why it was deprecated. 

When the table was deprecated, I think they incorrectly updated the search logic to go from `materialized_stockprop` (wide table, one row per stock) to `stockprop` (long table, multiple rows per stock).

My implementation is to create a new regular VIEW called `stockprops` which dynamically aggregates all stockprops into one `jsonb` column:

| stock_id | stockprops |
| --------- | ------------ |
| 41784  | `{"PUI": "http://localhost/stock/41784/view", "family": "test", "breeding_region": "test", ...}` |
| 41785 | `{"block": "3", "replicate": "3", "col_number": "3", ...}` |
| 41786 | `{"block": "8", "replicate": "8", "col_number": "3", ...`} |

This helps fix the broken search properties function. I think this view might also be handy to have in the future, since it could be nice to display these values as a table in the UI.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
