### PR TITLE
fieldmap: enhancements for family name and cross name

### DIFF
--- a/js/source/entries/fieldmap_react.tsx
+++ b/js/source/entries/fieldmap_react.tsx
@@ -272,8 +272,8 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
 
     const [plotLayout, setPlotLayout] = useState<'serpentine' | 'zigzag'>('serpentine');
     const [invertRows, setInvertRows] = useState(false);
-    const [colorVar, setColorVar] = useState<'parity' | 'germplasm' | 'block'>('parity');
-    const [labelVar, setLabelVar] = useState<'plot_number' | 'germplasm' | 'block'>('plot_number');
+    const [colorVar, setColorVar] = useState<'parity' | 'germplasm' | 'block' | 'family_name' | 'cross_name'>('parity');
+    const [labelVar, setLabelVar] = useState<'plot_number' | 'germplasm' | 'block' | 'family_name' | 'cross_name'>('plot_number');
     const [labelSize, setLabelSize] = useState(10);
 
     const [invertCols, setInvertCols] = useState(false);
@@ -316,7 +316,9 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
         obsUnit: false,
         seedlot: false,
         plotId: false,
-        plotNum: false
+        plotNum: false,
+        familyName: false,
+        crossName: false,
     });
 
     const clickTimer = useRef<NodeJS.Timeout | null>(null);
@@ -594,6 +596,28 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
         const mapping: Record<string, string> = {};
         blocks.sort().forEach((block, i) => {
             mapping[block] = palette[i % palette.length];
+        });
+        return mapping;
+    }, [plotList]);
+
+    const familyNamePalette = useMemo(() => {
+        const family_names = Array.from(new Set(plotList.map(p => {
+            return p.additionalInfo?.familyName || '';
+        }))).filter(b => b !== '');
+        const mapping: Record<string, string> = {};
+        family_names.sort().forEach((family_name, i) => {
+            mapping[family_name] = palette[i % palette.length];
+        });
+        return mapping;
+    }, [plotList]);
+
+    const crossNamePalette = useMemo(() => {
+        const cross_names = Array.from(new Set(plotList.map(p => {
+            return p.crossName || '';
+        }))).filter(b => b !== '');
+        const mapping: Record<string, string> = {};
+        cross_names.sort().forEach((cross_name, i) => {
+            mapping[cross_name] = palette[i % palette.length];
         });
         return mapping;
     }, [plotList]);
@@ -1300,6 +1324,12 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
             if (csvDownloadOpts.plotNum && plot.observationUnitPosition.observationLevel?.levelCode) {
                 cellVal += (cellVal ? '\n' : '') + plot.observationUnitPosition.observationLevel.levelCode;
             }
+            if (csvDownloadOpts.familyName && plot.additionalInfo?.familyName) {
+                cellVal += (cellVal ? '\n' : '') + plot.additionalInfo?.familyName;
+            }
+            if (csvDownloadOpts.crossName && plot.crossName) {
+                cellVal += (cellVal ? '\n' : '') + plot.additionalInfo?.crossName;
+            }
 
             coord_matrix[r][c] = `"${cellVal}"`;
         });
@@ -1567,6 +1597,8 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
                                     <option value="parity">Default (Parity)</option>
                                     <option value="germplasm">{stockLabel}</option>
                                     <option value="block">Block Number</option>
+                                    <option value="family_name">Family</option>
+                                    <option value="cross_name">Cross</option>
                                 </select>
                             </div>
                             <div className="form-inline">
@@ -1575,6 +1607,8 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
                                     <option value="plot_number">Plot Number</option>
                                     <option value="germplasm">{stockLabel} Name</option>
                                     <option value="block">Block Number</option>
+                                    <option value="family_name">Family</option>
+                                    <option value="cross_name">Cross</option>
                                 </select>
                             </div>
                             <div className="form-inline">
@@ -1642,6 +1676,16 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
                                                         const block = plot.observationUnitPosition?.observationLevelRelationships?.find(r => r.levelName === 'block')?.levelCode || '';
                                                         if (block && blockPalette[block]) {
                                                             fill = blockPalette[block];
+                                                        }
+                                                    } else if (colorVar === 'family_name') {
+                                                        const family_name = plot.additionalInfo?.familyName || '';
+                                                        if (family_name && familyNamePalette[family_name]) {
+                                                            fill = familyNamePalette[family_name];
+                                                        }
+                                                    } else if (colorVar === 'cross_name') {
+                                                        const cross_name = plot.crossName || '';
+                                                        if (cross_name && crossNamePalette[cross_name]) {
+                                                            fill = crossNamePalette[cross_name];
                                                         }
                                                     } else {
                                                         // Replicate even/odd stroke coloring
@@ -1769,6 +1813,10 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
                                                     if (labelText === 'Filler') labelText = '';
                                                 } else if (labelVar === 'block') {
                                                     labelText = plot.observationUnitPosition?.observationLevelRelationships?.find(r => r.levelName === 'block')?.levelCode || '';
+                                                } else if (labelVar === 'family_name') {
+                                                    labelText = plot.additionalInfo?.familyName || '';
+                                                } else if (labelVar === 'cross_name') {
+                                                    labelText = plot.crossName || '';
                                                 }
 
                                                 if (!labelText) return null;
@@ -1929,7 +1977,7 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
                             </div>
                             <div className="modal-body">
                                 <div className="checkbox">
-                                    <label><input type="checkbox" checked={csvDownloadOpts.accession} onChange={e => setCsvDownloadOpts({ ...csvDownloadOpts, accession: e.target.checked })} /> Cross / Accession Name</label>
+                                    <label><input type="checkbox" checked={csvDownloadOpts.accession} onChange={e => setCsvDownloadOpts({ ...csvDownloadOpts, accession: e.target.checked })} /> Accession Name</label>
                                 </div>
                                 <div className="checkbox">
                                     <label><input type="checkbox" checked={csvDownloadOpts.obsUnit} onChange={e => setCsvDownloadOpts({ ...csvDownloadOpts, obsUnit: e.target.checked })} /> Plot Name</label>
@@ -1942,6 +1990,12 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
                                 </div>
                                 <div className="checkbox">
                                     <label><input type="checkbox" checked={csvDownloadOpts.plotNum} onChange={e => setCsvDownloadOpts({ ...csvDownloadOpts, plotNum: e.target.checked })} /> Plot Number</label>
+                                </div>
+                                <div className="checkbox">
+                                    <label><input type="checkbox" checked={csvDownloadOpts.familyName} onChange={e => setCsvDownloadOpts({ ...csvDownloadOpts, familyName: e.target.checked })} /> Family</label>
+                                </div>
+                                <div className="checkbox">
+                                    <label><input type="checkbox" checked={csvDownloadOpts.crossName} onChange={e => setCsvDownloadOpts({ ...csvDownloadOpts, crossName: e.target.checked })} /> Cross</label>
                                 </div>
                             </div>
                             <div className="modal-footer">

--- a/lib/CXGN/Trial/TrialLayoutSearch.pm
+++ b/lib/CXGN/Trial/TrialLayoutSearch.pm
@@ -145,6 +145,9 @@ sub search {
     my $additional_info_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'stock_additional_info', 'stock_property')->cvterm_id();
     my $plot_geo_json_type_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'plot_geo_json', 'stock_property')->cvterm_id();
 
+    my $offspring_of_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'offspring_of', 'stock_relationship')->cvterm_id();
+    my $cross_member_of_type_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'cross_member_of', 'stock_relationship')->cvterm_id();
+
     my $numeric_regex = '^-?[0-9]+([,.][0-9]+)?$';
 
     #For performance reasons the number of joins to stock can be reduced if a trial is given.
@@ -176,14 +179,18 @@ sub search {
         LEFT JOIN stockprop AS additional_info ON (observationunit.stock_id=additional_info.stock_id AND additional_info.type_id = $additional_info_type_id)
         LEFT JOIN stockprop AS plot_geo_json ON (observationunit.stock_id=plot_geo_json.stock_id AND plot_geo_json.type_id = $plot_geo_json_type_id)
         LEFT JOIN phenome.stock_image ON (observationunit.stock_id = stock_image.stock_id)
-        left join metadata.md_image on (stock_image.image_id = md_image.image_id) ";
+        left join metadata.md_image on (stock_image.image_id = md_image.image_id)
+        left join stock_relationship r_cross on (germplasm.stock_id = r_cross.subject_id and r_cross.type_id = $offspring_of_type_id)
+        left join stock stock_cross on (stock_cross.stock_id = r_cross.object_id)
+        left join stock_relationship r_family on (r_family.subject_id = r_cross.object_id and r_family.type_id = $cross_member_of_type_id)
+        left join stock stock_family on (stock_family.stock_id = r_family.object_id) ";
 
 
-    my $select_clause = "SELECT observationunit.stock_id, observationunit.uniquename, observationunit_type.name, germplasm.uniquename, germplasm.stock_id, germplasm_type.name, project.project_id, project.name, project.description, breeding_program.project_id, breeding_program.name, breeding_program.description, folder.project_id, folder.name, folder.description,rep.value, block_number.value, plot_number.value, is_a_control.value, row_number.value, col_number.value, plant_number.value, location.value, seedlot.stock_id, seedlot.uniquename, count(observationunit.stock_id) OVER() AS full_count, min(additional_info.value) as additional_info, min(plot_geo_json.value) as plot_geo_json, array_agg(distinct stock_image.image_id) as image_ids, STRING_AGG(DISTINCT(istock.stock_id::text), '|'), STRING_AGG(DISTINCT(istock.uniquename), ',') ";
+    my $select_clause = "SELECT observationunit.stock_id, observationunit.uniquename, observationunit_type.name, germplasm.uniquename, germplasm.stock_id, germplasm_type.name, stock_cross.uniquename, stock_cross.stock_id, stock_family.uniquename, stock_family.stock_id, project.project_id, project.name, project.description, breeding_program.project_id, breeding_program.name, breeding_program.description, folder.project_id, folder.name, folder.description,rep.value, block_number.value, plot_number.value, is_a_control.value, row_number.value, col_number.value, plant_number.value, location.value, seedlot.stock_id, seedlot.uniquename, count(observationunit.stock_id) OVER() AS full_count, min(additional_info.value) as additional_info, min(plot_geo_json.value) as plot_geo_json, array_agg(distinct stock_image.image_id) as image_ids, STRING_AGG(DISTINCT(istock.stock_id::text), '|'), STRING_AGG(DISTINCT(istock.uniquename), ',') ";
 
     my $order_clause = $self->order_by ? " ORDER BY ".$self->order_by : " ORDER BY project.name, observationunit.uniquename";
 
-    my $group_by = " GROUP BY observationunit.stock_id, observationunit.uniquename, observationunit_type.name, germplasm.uniquename, germplasm.stock_id, germplasm_type.name, project.project_id, project.name, project.description, breeding_program.project_id, breeding_program.name, breeding_program.description, folder.project_id, folder.name, folder.description, rep.value, block_number.value, plot_number.value, is_a_control.value, row_number.value, col_number.value, plant_number.value, location.value, seedlot.stock_id, seedlot.uniquename ";
+    my $group_by = " GROUP BY observationunit.stock_id, observationunit.uniquename, observationunit_type.name, germplasm.uniquename, germplasm.stock_id, germplasm_type.name, stock_cross.uniquename, stock_cross.stock_id, stock_family.uniquename, stock_family.stock_id, project.project_id, project.name, project.description, breeding_program.project_id, breeding_program.name, breeding_program.description, folder.project_id, folder.name, folder.description, rep.value, block_number.value, plot_number.value, is_a_control.value, row_number.value, col_number.value, plant_number.value, location.value, seedlot.stock_id, seedlot.uniquename ";
 
     # WHERE
     my @where_clause;
@@ -255,7 +262,7 @@ sub search {
 
     my @observation_units;
 
-    while (my ($observationunit_stock_id, $observationunit_uniquename, $observationunit_type_name, $germplasm_uniquename, $germplasm_stock_id, $germplasm_type_name, $project_project_id, $project_name, $project_description, $breeding_program_project_id, $breeding_program_name, $breeding_program_description,
+    while (my ($observationunit_stock_id, $observationunit_uniquename, $observationunit_type_name, $germplasm_uniquename, $germplasm_stock_id, $germplasm_type_name, $cross_name, $cross_stock_id, $family_name, $family_stock_id, $project_project_id, $project_name, $project_description, $breeding_program_project_id, $breeding_program_name, $breeding_program_description,
     $folder_id, $folder_name, $folder_description, $rep, $block_number, $plot_number, $is_a_control, $row_number, $col_number, $plant_number, $location_id, $seedlot_id, $seedlot_name, $full_count, $additional_info, $plot_geo_json, $image_ids, $intercrop_stock_id, $intercrop_stock_name) = $h->fetchrow_array()) {
 
         my $location_name = $location_id ? $location_id_lookup{$location_id} : undef;
@@ -268,11 +275,6 @@ sub search {
 
         my $accession_stock_id;
         my $accession_name;
-        my $cross_stock_id;
-        my $cross_name;
-        my $family_stock_id;
-        my $family_name;
-
 
         if ($germplasm_type_name eq 'cross') {
             $cross_stock_id = $germplasm_stock_id;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR adds some additional enhancements for using the `family_name` and `cross_name` as variables for labeling and coloring the heatmap. When a trial source is an `accession`, the backend now retrieves extra relational information about which cross produced that accession, and what family it is part of.

<!-- If there are relevant issues, link them here: -->
- Resolves #136 


| germplasm | family | cross |
| -- | -- | -- |
|  <img width="327" height="217" alt="image" src="https://github.com/user-attachments/assets/1f089f1a-5994-44ae-981d-c9b4c282c121" />   |  <img width="311" height="223" alt="image" src="https://github.com/user-attachments/assets/eb15d1d5-0fb2-423e-9d70-adddc8b9660e" />  | <img width="324" height="223" alt="image" src="https://github.com/user-attachments/assets/4283689b-62b4-4056-98cf-087b72f85f89" /> |

New dropdown options:

| Color and Label | Download |
| --- | --- |
| <img width="480" alt="image" src="https://github.com/user-attachments/assets/071bdc83-480f-4d95-84f5-4c45f8509a93" /> | <img width="584" height="355" alt="image" src="https://github.com/user-attachments/assets/923e5981-c8e5-4e32-baf0-6ac65134dc2b" /> |

This is the pedigree I was building for testing, `test_accession_3` is an open cross that produces `test_accession_2` which is an open cross for `test_accession`:
<img width="480" alt="image" src="https://github.com/user-attachments/assets/67903118-12c0-4df5-9f9f-a1e81fc34101" />


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
