### PR TITLE
fieldmap: delay init until onswitch is clicked

### DIFF
--- a/mason/breeders_toolbox/trial/phenotype_heatmap.mas
+++ b/mason/breeders_toolbox/trial/phenotype_heatmap.mas
@@ -18,13 +18,15 @@ jQuery(document).ready(function() {
     var auth_token = "<%  CXGN::Login->new($c->dbc->dbh)->get_login_cookie() %>";
     var require_login = "<%  $c->get_conf('brapi_require_login') %>";
 
-    window.jsMod['fieldmap_react'].init('fieldmap_react_root', {
-        trialId: '<% $trial_id %>',
-        trialStockType: '<% $trial_stock_type %>',
-        hasColAndRowNumbers: <% $has_col_and_row_numbers ? 'true' : 'false' %>,
-        hasSubplotEntries: <% $has_subplot_entries ? 'true' : 'false' %>,
-        hasPlantEntries: <% $has_plant_entries ? 'true' : 'false' %>,
-        authToken: auth_token
+    jQuery("#pheno_heatmap_onswitch").click(function() {
+        window.jsMod['fieldmap_react'].init('fieldmap_react_root', {
+            trialId: '<% $trial_id %>',
+            trialStockType: '<% $trial_stock_type %>',
+            hasColAndRowNumbers: <% $has_col_and_row_numbers ? 'true' : 'false' %>,
+            hasSubplotEntries: <% $has_subplot_entries ? 'true' : 'false' %>,
+            hasPlantEntries: <% $has_plant_entries ? 'true' : 'false' %>,
+            authToken: auth_token
+        });
     });
 });
 </script>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Delay the initialization of the fieldmap until the accordion onswitch is clicked. Otherwise a working dialog pops up when the trial page is initially loaded, which can block for 5-10 seconds for large trials.

<!-- If there are relevant issues, link them here: -->
- Resolves #138 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
