### PR TITLE
fieldmap: simplify variable access

### DIFF
--- a/js/source/entries/fieldmap_react.tsx
+++ b/js/source/entries/fieldmap_react.tsx
@@ -421,20 +421,20 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
             .then(response => {
                 const units = response?.result?.data || [];
                 if (units.length > 0) {
-                    const first = units[0];
-                    if (first.additionalInfo) {
-                        setTopBorder(!!first.additionalInfo.top_border_selection);
-                        setLeftBorder(!!first.additionalInfo.left_border_selection);
-                        setRightBorder(!!first.additionalInfo.right_border_selection);
-                        setBottomBorder(!!first.additionalInfo.bottom_border_selection);
-                        setInvertRows(!!first.additionalInfo.invert_row_checkmark);
-                        setInvertCols(!!first.additionalInfo.invert_col_checkmark);
-                        if (first.additionalInfo.plot_layout) {
-                            setPlotLayout(first.additionalInfo.plot_layout);
+                    const firstInfo = units[0].additionalInfo;
+                    if (firstInfo) {
+                        setTopBorder(firstInfo.top_border_selection);
+                        setLeftBorder(firstInfo.left_border_selection);
+                        setRightBorder(firstInfo.right_border_selection);
+                        setBottomBorder(firstInfo.bottom_border_selection);
+                        setInvertRows(firstInfo.invert_row_checkmark);
+                        setInvertCols(firstInfo.invert_col_checkmark);
+                        if (firstInfo.plot_layout) {
+                            setPlotLayout(firstInfo.plot_layout);
                         }
-                        if (first.additionalInfo.plot_color_var) setColorVar(first.additionalInfo.plot_color_var);
-                        if (first.additionalInfo.plot_label_var) setLabelVar(first.additionalInfo.plot_label_var);
-                        if (first.additionalInfo.plot_label_size) setLabelSize(first.additionalInfo.plot_label_size);
+                        if (firstInfo.plot_color_var) setColorVar(firstInfo.plot_color_var);
+                        if (firstInfo.plot_label_var) setLabelVar(firstInfo.plot_label_var);
+                        if (firstInfo.plot_label_size) setLabelSize(firstInfo.plot_label_size);
                     }
                     parsePlotData(units);
                 }


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Noticed some overly nested variable access while re-reading the fieldmap component. Made the local reference variable one level more specific to reduce repetition.
<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
