### PR TITLE
search: persist the last selected submit button in the url

### DIFF
--- a/js/source/entries/search_state.ts
+++ b/js/source/entries/search_state.ts
@@ -360,11 +360,9 @@ export class SearchStateManager {
             urlParams.delete(key);
         }
 
-        // If this is a full reset, purge the submit button parameter as well
-        if (!keys) {
-            this.lastClickedSubmitButton = null;
-            urlParams.delete('submit_button');
-        }
+        // Any reset should also clear the last clicked submit button
+        this.lastClickedSubmitButton = null;
+        urlParams.delete('submit_button');
 
         const qString = urlParams.toString();
         const nextUrl = qString ? '?' + qString : window.location.pathname;

--- a/js/source/entries/search_state.ts
+++ b/js/source/entries/search_state.ts
@@ -102,6 +102,7 @@ export class SearchStateManager {
     private readonly config: SearchStateConfig;
     private readonly submitSelectors: string[];
     private readonly resetSelectors?: string[] | Record<string, string[]>;
+    private lastClickedSubmitButton: string | null = null;
 
     constructor(config: SearchStateConfig) {
         this.config = config;
@@ -164,6 +165,11 @@ export class SearchStateManager {
                 }
             }
         }
+
+        if (this.lastClickedSubmitButton) {
+            params['submit_button'] = this.lastClickedSubmitButton;
+        }
+
         return params;
     }
 
@@ -176,6 +182,11 @@ export class SearchStateManager {
      */
     public async deserialize(): Promise<void> {
         const urlParams = new URLSearchParams(window.location.search);
+
+        const submitButtonParam = urlParams.get('submit_button');
+        if (submitButtonParam) {
+            this.lastClickedSubmitButton = submitButtonParam;
+        }
 
         for (const [key, element] of Object.entries(this.config.elements)) {
             const val = urlParams.get(key);
@@ -349,6 +360,12 @@ export class SearchStateManager {
             urlParams.delete(key);
         }
 
+        // If this is a full reset, purge the submit button parameter as well
+        if (!keys) {
+            this.lastClickedSubmitButton = null;
+            urlParams.delete('submit_button');
+        }
+
         const qString = urlParams.toString();
         const nextUrl = qString ? '?' + qString : window.location.pathname;
 
@@ -375,6 +392,7 @@ export class SearchStateManager {
         // Intercept the search execution event to update query params and trigger callbacks
         this.submitSelectors.forEach(selector => {
             jQuery(selector).on('click', () => {
+                this.lastClickedSubmitButton = selector;
                 this.updateUrl();
                 if (this.config.onSearch) {
                     this.config.onSearch();
@@ -409,7 +427,10 @@ export class SearchStateManager {
             .filter(key => urlParams.has(key));
 
         if (restoredKeys.length > 0) {
-            if (this.config.onRestore) {
+            const restoredSubmitButton = urlParams.get('submit_button');
+            if (restoredSubmitButton && this.submitSelectors.includes(restoredSubmitButton)) {
+                jQuery(restoredSubmitButton).trigger('click');
+            } else if (this.config.onRestore) {
                 this.config.onRestore(restoredKeys);
             } else if (this.submitSelectors.length === 1) {
                 // Fall back to triggering the single submit button only if there is no ambiguity

--- a/js/test/search_state.test.ts
+++ b/js/test/search_state.test.ts
@@ -243,3 +243,53 @@ test('SearchStateManager - Resetting Form State', async (t) => {
 
     t.end();
 });
+
+test('SearchStateManager - Multiple Submit Buttons Persistence & Restore', async (t) => {
+    document.body.innerHTML = `
+        <div id="test_form">
+            <input type="text" id="test_name" value="Solanum" />
+            <button id="btn_search_a">Search A</button>
+            <button id="btn_search_b">Search B</button>
+        </div>
+    `;
+    clearURL();
+
+    let searchCallbackCalled = false;
+    const manager = create({
+        submitButtonSelector: ['#btn_search_a', '#btn_search_b'],
+        onSearch: () => {
+            searchCallbackCalled = true;
+        },
+        elements: {
+            name: { selector: '#test_name' }
+        }
+    });
+
+    await manager.init();
+
+    // Click Search B
+    jQuery('#btn_search_b').trigger('click');
+
+    const updatedParams = new URLSearchParams(window.location.search);
+    t.equal(updatedParams.get('name'), 'Solanum', 'Commits state');
+    t.equal(updatedParams.get('submit_button'), '#btn_search_b', 'Persists clicked submit button selector to URL parameter');
+    t.ok(searchCallbackCalled, 'Callback called');
+
+    // Now test restore with that submit_button parameter
+    let restoredClickOnB = false;
+    jQuery('#btn_search_b').on('click', () => {
+        restoredClickOnB = true;
+    });
+
+    const managerRestore = create({
+        submitButtonSelector: ['#btn_search_a', '#btn_search_b'],
+        elements: {
+            name: { selector: '#test_name' }
+        }
+    });
+
+    await managerRestore.init();
+    t.ok(restoredClickOnB, 'Automatically triggers click on the restored submit button on load');
+
+    t.end();
+});

--- a/mason/search/cross/cross_search_using_female.mas
+++ b/mason/search/cross/cross_search_using_female.mas
@@ -169,13 +169,6 @@ jQuery(document).ready(function (){
                 type: 'select',
                 waitForOptions: true
             }
-        },
-        onRestore: function(restoredKeys) {
-            if (restoredKeys.includes('male_parent')) {
-                jQuery('#search_crosses_female_male').click();
-            } else if (restoredKeys.includes('female_parent')) {
-                jQuery('#search_all_crosses_using_female').click();
-            }
         }
     });
     searchManager.init();

--- a/mason/search/cross/cross_search_using_male.mas
+++ b/mason/search/cross/cross_search_using_male.mas
@@ -169,13 +169,6 @@ jQuery(document).ready(function (){
                 type: 'select',
                 waitForOptions: true
             }
-        },
-        onRestore: function(restoredKeys) {
-            if (restoredKeys.includes('female_parent')) {
-                jQuery('#search_crosses_male_female').click();
-            } else if (restoredKeys.includes('male_parent')) {
-                jQuery('#search_all_crosses_using_male').click();
-            }
         }
     });
     searchManager.init();

--- a/mason/search/cross/progeny_search_using_female.mas
+++ b/mason/search/cross/progeny_search_using_female.mas
@@ -168,13 +168,6 @@ jQuery(document).ready(function (){
                 type: 'select',
                 waitForOptions: true
             }
-        },
-        onRestore: function(restoredKeys) {
-            if (restoredKeys.includes('male_parent')) {
-                jQuery('#search_pedigree_female_male').click();
-            } else if (restoredKeys.includes('female_parent')) {
-                jQuery('#search_all_progenies_using_female').click();
-            }
         }
     });
     searchManager.init();

--- a/mason/search/cross/progeny_search_using_male.mas
+++ b/mason/search/cross/progeny_search_using_male.mas
@@ -167,13 +167,6 @@ jQuery(document).ready(function (){
                 type: 'select',
                 waitForOptions: true
             }
-        },
-        onRestore: function(restoredKeys) {
-            if (restoredKeys.includes('female_parent')) {
-                jQuery('#search_pedigree_male_female').click();
-            } else if (restoredKeys.includes('male_parent')) {
-                jQuery('#search_all_progenies_using_male').click();
-            }
         }
     });
     searchManager.init();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This pull request resolves an issue with cross and progeny search pages where refreshes or bookmark-restorations would trigger the incorrect search action (e.g., defaulting to the specific parent-to-parent search instead of "All Crosses" or "All Progenies").

### The Problem
On search pages featuring multiple submission buttons (such as searching for all progenies of a single female parent versus searching for progenies of a specific female and male parent pair), the field values for both inputs are often populated and persisted to the URL query parameters.

Prior to this change, upon page refresh, the `onRestore` callback had to guess which search button to trigger based on the presence of parameters in the URL (e.g., if both `female_parent` and `male_parent` were in the URL, it would run the combined parent-to-parent search). However, if a user had filled out both fields but originally clicked the "All Crosses" button (ignoring the male parent field), refreshing the page would incorrectly execute the combined search instead of the "All Crosses" search.

### The Solution
The declarative `SearchStateManager` utility has been enhanced to serialize and restore the exact submit button that triggered the query. 
1. **Button Tracking**: On click, the ID or selector of the clicked submit button is tracked as a `submit_button` query parameter in the URL.
2. **Automated Restoration**: Upon page refresh/deserialization, `SearchStateManager` automatically triggers a click event on the restored button.
3. **Template Simplification**: Fragile, custom `onRestore` heuristics in individual Mason templates have been removed in favor of this reliable, centralized logic.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [x] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
