### PR TITLE
fix: remove duplicated select elements

### DIFF
--- a/mason/search/cross/cross_search_using_female.mas
+++ b/mason/search/cross/cross_search_using_female.mas
@@ -25,7 +25,6 @@
                                     <select class="form-control" id="cross_male_parent">
                                         <option value="">Choose female parent first</option>
                                     </select>
-                                    </select>
                                     <div class="input-group-btn">
                                         <button class="btn btn-info" id="search_crosses_female_male"><i class="glyphicon glyphicon-search"></i> Cross Info </button>
                                     </div>
@@ -90,11 +89,10 @@ jQuery(document).ready(function (){
             url: '/ajax/search/cross_male_parents',
             data: { 'female_parent': female },
             success: function(response) {
-                var html = '<select id="cross_male_parent" class="form-control">';
+                var html = '';
                 for (var i = 0; i < response.data.length; i++) {
                     html += "<option value='" + response.data[i][0] + "'>" + response.data[i][0] + "</option>";
                 }
-                html += "</select>";
                 jQuery('#cross_male_parent').html(html);
             }
         });

--- a/mason/search/cross/cross_search_using_male.mas
+++ b/mason/search/cross/cross_search_using_male.mas
@@ -25,7 +25,6 @@
                                     <select class="form-control" id="cross_female">
                                         <option value="">Choose male parent first</option>
                                     </select>
-                                    </select>
                                     <div class="input-group-btn">
                                         <button class="btn btn-info" id="search_crosses_male_female"><i class="glyphicon glyphicon-search"></i> Cross Info </button>
                                     </div>
@@ -91,11 +90,10 @@ jQuery(document).ready(function (){
             url: '/ajax/search/cross_female_parents',
             data: { 'male_parent': male },
             success: function(response) {
-                var html = '<select id="cross_female" class="form-control">';
+                var html = '';
                 for (var i = 0; i < response.data.length; i++) {
                     html += "<option value='" + response.data[i][0] + "'>" + response.data[i][0] + "</option>";
                 }
-                html += "</select>";
                 jQuery('#cross_female').html(html);
             }
         });

--- a/mason/search/cross/progeny_search_using_female.mas
+++ b/mason/search/cross/progeny_search_using_female.mas
@@ -25,7 +25,6 @@
                                     <select class="form-control" id="pedigree_male_parent">
                                         <option value="">Choose female parent first</option>
                                     </select>
-                                    </select>
                                     <div class="input-group-btn">
                                         <button class="btn btn-info" id="search_pedigree_female_male"><i class="glyphicon glyphicon-search"></i> Progenies of these Parents </button>
                                     </div>
@@ -89,11 +88,10 @@ jQuery(document).ready(function (){
             url: '/ajax/search/pedigree_male_parents',
             data: { 'pedigree_female_parent': female },
             success: function(response) {
-                var html = '<select id="pedigree_male_parent" class="form-control">';
+                var html = '';
                 for (var i = 0; i < response.data.length; i++) {
                     html += "<option value='" + response.data[i][0] + "'>" + response.data[i][0] + "</option>";
                 }
-                html += "</select>";
                 jQuery('#pedigree_male_parent').html(html);
             }
         });

--- a/mason/search/cross/progeny_search_using_male.mas
+++ b/mason/search/cross/progeny_search_using_male.mas
@@ -25,7 +25,6 @@
                                     <select class="form-control" id="female_parent">
                                         <option value="">Choose male parent first</option>
                                     </select>
-                                    </select>
                                     <div class="input-group-btn">
                                         <button class="btn btn-info" id="search_pedigree_male_female"><i class="glyphicon glyphicon-search"></i> Progenies of these Parents </button>
                                     </div>
@@ -88,11 +87,10 @@ jQuery(document).ready(function (){
             url: '/ajax/search/pedigree_female_parents',
             data: { 'pedigree_male_parent': male },
             success: function(response) {
-                var html = '<select id="female_parent" class="form-control">';
+                var html = '';
                 for (var i = 0; i < response.data.length; i++) {
                     html += "<option value='" + response.data[i][0] + "'>" + response.data[i][0] + "</option>";
                 }
-                html += "</select>";
                 jQuery('#female_parent').html(html);
             }
         });


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Removes duplicated select elements in the crosses search pages.
<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
