### PR TITLE
fix: explicit defined checks so zero trait values display properly in phenotype heatmap

### DIFF
--- a/lib/CXGN/BrAPI/v2/Observations.pm
+++ b/lib/CXGN/BrAPI/v2/Observations.pm
@@ -295,7 +295,7 @@ sub _search {
     my $counter = 0;
 
     foreach (@$data){
-        if ( ($_->{phenotype_value} && $_->{phenotype_value} ne "") || ($_->{phenotype_value} && $_->{phenotype_value} eq '0') ) {
+        if ( defined($_->{phenotype_value}) && $_->{phenotype_value} ne "" ) {
             my $observation_id = "$_->{phenotype_id}";
             my $additional_info;
             my $external_references;
@@ -360,5 +360,3 @@ sub _search {
 
 
 1;
-
-


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Closes #160 

The problem was with the backend in `lib/CXGN/BrAPI/v2/Observations.pm`

```diff
-        if ( ($_->{phenotype_value} && $_->{phenotype_value} ne "") || ($_->{phenotype_value} && $_->{phenotype_value} eq '0') ) {
+        if ( defined($_->{phenotype_value}) && $_->{phenotype_value} ne "" ) {
```

On both sides of the OR, the first conditional "$_->{phenotype_value}" would evaluate to false since '0' is falsy in perl. Simplifying the conditional to explicitly filter only undefined and empty strings fixes the issue.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
