### PR TITLE
fix: show full composed trait names in selection index dropdown

### DIFF
--- a/js/source/legacy/CXGN/SelectionIndex.js
+++ b/js/source/legacy/CXGN/SelectionIndex.js
@@ -19,7 +19,7 @@ jQuery(document).ready(function() {
             jQuery('#trait_table').html("");
             jQuery('#weighted_values_div').html("");
             jQuery('#raw_avgs_div').html("");
-            jQuery('#sin_formula_list_select').val("");
+            jQuery('#sin_list_list_select').val("");
             update_formula();
 
             if (jQuery(this).val() == '') {
@@ -416,7 +416,7 @@ function load_sin() { // update traits and selection index when a saved sin form
     }
 
     //retrieve contents of list:
-    var sin_list_id = jQuery('#sin_formula_list_select').val();
+    var sin_list_id = jQuery('#sin_list_list_select').val();
     if (!sin_list_id) {
         update_formula();
         return;

--- a/js/source/legacy/CXGN/SelectionIndex.js
+++ b/js/source/legacy/CXGN/SelectionIndex.js
@@ -73,15 +73,13 @@ jQuery(document).ready(function() {
                             synonyms = response.synonyms;
                             //console.log("synonyms = " + JSON.stringify(synonyms));
                             trait_html = '<option id="select_message" value="" title="Select a trait">Select a trait</option>\n';
-                            for (i = 0; i < list.length; i++) {
-                                var trait_id = list[i][0];
-                                var trait_name = list[i][1];
-                                var parts = trait_name.split("|");
-                                var synonym = synonyms[trait_id];
-                            //    synonym_fixed = synonym.replace(/"/g, "");
-                            //    var syn_parts = synonym_fixed.split(" ");
-                              //  synonym_fixed = syn_parts[0];
-                                trait_html += '<option value="' + trait_id + '" data-synonym="' + synonym + '" data-list_name="' + trait_name + '" title="' + parts[0] + '">' + parts[0] + '</a>\n';
+                            for (let i = 0; i < list.length; i++) {
+                                const trait_id = list[i][0];
+                                const trait_name = list[i][1];
+                                const parts = trait_name.split("|");
+                                const synonym = synonyms[trait_id];
+                                const trait_display = parts.length > 1 ? parts.slice(0, -1).join("|") : parts[0];
+                                trait_html += '<option value="' + trait_id + '" data-synonym="' + synonym + '" data-list_name="' + trait_name + '" title="' + trait_display + '">' + trait_display + '</option>\n';
                             }
 
                             jQuery('#trait_list').html(trait_html);
@@ -122,23 +120,23 @@ jQuery(document).ready(function() {
                             var accessions = response.accessions;
                             var accession_html;
                             if (response.accessions[0].length == 0) {
-                                accession_html = '<option value="" title="Select a control">No controls found</a>\n';
+                                accession_html = '<option value="" title="Select a control">No controls found</option>\n';
                             } else {
-                                accession_html = '<option value="" title="Select a control">Select a control</a>\n';
+                                accession_html = '<option value="" title="Select a control">Select a control</option>\n';
                                 for (i = 0; i < response.accessions[0].length; i++) {
-                                    accession_html += '<option value="' + accessions[0][i].stock_id + '" title="' + response.accessions[0][i].stock_id + '">' + response.accessions[0][i].accession_name + '</a>\n';
+                                    accession_html += '<option value="' + accessions[0][i].stock_id + '" title="' + response.accessions[0][i].stock_id + '">' + response.accessions[0][i].accession_name + '</option>\n';
                                 }
                             }
                             jQuery('#control_list').html(accession_html);
                             jQuery('#trait_list').focus();
                         },
                         error: function(response) {
-                            jQuery('#control_list').html('<option value="" title="Select a control">Error retrieving trial controls</a>');
+                            jQuery('#control_list').html('<option value="" title="Select a control">Error retrieving trial controls</option>');
                         }
                     });
                 },
                 error: function(response) {
-                    jQuery('#control_list').html('<option value="" title="Select a control">Error retrieving trial design</a>');
+                    jQuery('#control_list').html('<option value="" title="Select a control">Error retrieving trial design</option>');
                 }
             });
         });

--- a/t/selenium2/analysis/selection_index.t
+++ b/t/selenium2/analysis/selection_index.t
@@ -3,8 +3,63 @@ use lib 't/lib';
 
 use Test::More;
 use SGN::Test::WWW::WebDriver;
+use SGN::Test::Fixture;
+use CXGN::BreederSearch;
+use CXGN::Onto;
 
 my $d = SGN::Test::WWW::WebDriver->new();
+my $f = SGN::Test::Fixture->new();
+my $schema = $f->bcs_schema;
+
+my $dry_matter_cvterm = $schema->resultset("Cv::Cvterm")->find({ name => "dry matter content percentage" });
+my $dry_matter_id = $dry_matter_cvterm->cvterm_id();
+
+my $fresh_root_cvterm = $schema->resultset("Cv::Cvterm")->find({ name => "fresh root weight" });
+my $fresh_root_id = $fresh_root_cvterm->cvterm_id();
+
+# Setup a composed trait with multiple pipe delimiters using the standard Onto library
+my $onto = CXGN::Onto->new({ schema => $schema });
+my $new_terms = $onto->store_composed_term({
+    "composed trait name|CO_334:1234567" => "$dry_matter_id,$fresh_root_id"
+}, 'trait');
+
+my $composed_cvterm_id = $new_terms->[0]->[0];
+my $composed_cvterm = $schema->resultset("Cv::Cvterm")->find({ cvterm_id => $composed_cvterm_id });
+
+my $trial = $schema->resultset("Project::Project")->find({ name => "Kasese solgs trial" });
+my $existing_nd_experiment_phenotype = $schema->resultset("NaturalDiversity::NdExperimentPhenotype")->search(
+    {
+        'nd_experiment_projects.project_id' => $trial->project_id(),
+        'phenotype.observable_id' => $dry_matter_id,
+    },
+    {
+        join => [ 'phenotype', { 'nd_experiment' => 'nd_experiment_projects' } ]
+    }
+)->first();
+my $nd_experiment_id = $existing_nd_experiment_phenotype->nd_experiment_id();
+
+my $phenotype = $schema->resultset("Phenotype::Phenotype")->create({
+    observable_id => $composed_cvterm_id,
+    cvalue_id => $composed_cvterm_id,
+    value => "10.5",
+    uniquename => "selenium_test_composed_phenotype_value",
+});
+
+$schema->resultset("NaturalDiversity::NdExperimentPhenotype")->create({
+    nd_experiment_id => $nd_experiment_id,
+    phenotype_id => $phenotype->phenotype_id(),
+});
+
+my $bs = CXGN::BreederSearch->new({ dbh => $schema->storage->dbh, dbname => $f->config->{dbname} });
+$bs->refresh_matviews(
+    $f->config->{dbhost},
+    $f->config->{dbname},
+    $f->config->{dbuser},
+    $f->config->{dbpass},
+    'fullview',
+    0,
+    $f->config->{basepath}
+);
 
 $d->while_logged_in_as("submitter", sub {
     $d->get_ok('/selection/index');
@@ -17,6 +72,12 @@ $d->while_logged_in_as("submitter", sub {
 
     # Wait for AJAX to populate traits list
     $d->wait_for_network_idle();
+
+    # Verify that the full composed trait name is shown in the dropdown (excluding only the last ID part)
+    $d->find_element_ok('//select[@id="trait_list"]/option[text()="composed trait name|CO_334:1234567"]', 'xpath', 'verify composed trait is visible with full name');
+
+    # Select the composed trait
+    $d->click_ok('//select[@id="trait_list"]/option[text()="composed trait name|CO_334:1234567"]', 'xpath', 'select composed trait');
 
     # Select a trait
     $d->click_ok('//select[@id="trait_list"]/option[text()="dry matter content percentage"]', 'xpath', 'select dry matter trait');
@@ -47,5 +108,6 @@ $d->while_logged_in_as("submitter", sub {
     $d->find_element_ok('//select[@id="sin_list_list_select"]/option[text()="test_sin_formula"]', 'xpath', 'verify saved formula is in dropdown');
 });
 
+$f->clean_up_db();
 $d->driver->quit();
 done_testing();

--- a/t/selenium2/analysis/selection_index.t
+++ b/t/selenium2/analysis/selection_index.t
@@ -1,0 +1,51 @@
+use strict;
+use lib 't/lib';
+
+use Test::More;
+use SGN::Test::WWW::WebDriver;
+
+my $d = SGN::Test::WWW::WebDriver->new();
+
+$d->while_logged_in_as("submitter", sub {
+    $d->get_ok('/selection/index');
+
+    # Wait for the select trial box to be visible
+    $d->find_element_ok('select_trial_for_selection_index', 'id', 'find select trial dropdown');
+
+    # Select the trial
+    $d->click_ok('//select[@id="select_trial_for_selection_index"]/option[text()="Kasese solgs trial"]', 'xpath', 'select Kasese solgs trial');
+
+    # Wait for AJAX to populate traits list
+    $d->wait_for_network_idle();
+
+    # Select a trait
+    $d->click_ok('//select[@id="trait_list"]/option[text()="dry matter content percentage"]', 'xpath', 'select dry matter trait');
+
+    # Verify that the trait was added to the table
+    $d->find_element_ok('trait_table', 'id', 'find trait table');
+
+    # Click calculate rankings
+    $d->click_ok('calculate_rankings', 'id', 'click calculate rankings button');
+
+    # Wait for calculation to finish
+    $d->wait_for_network_idle();
+
+    # Verify rankings table content
+    my $weighted_html = $d->get_attribute_ok('weighted_values_table', 'id', 'innerHTML', 'get weighted values table content');
+    ok($weighted_html =~ /UG12/, "verify accession is in rankings table");
+
+    # Test saving the formula
+    $d->send_keys_ok('save_sin_name', 'id', 'test_sin_formula', 'enter name for SIN formula');
+    $d->click_ok('save_sin', 'id', 'click save button');
+
+    # Accept the alert pop-up
+    $d->accept_alert_ok('accept saved SIN formula alert');
+
+    # Verify that the saved formula is in the saved formulas dropdown
+    $d->click_ok('sin_list_list_refresh', 'id', 'click refresh button for SIN formulas');
+    $d->wait_for_network_idle();
+    $d->find_element_ok('//select[@id="sin_list_list_select"]/option[text()="test_sin_formula"]', 'xpath', 'verify saved formula is in dropdown');
+});
+
+$d->driver->quit();
+done_testing();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Composed trait names now show fully including pipes on the Analysis->Selection Index page.

<img width="737" height="803" alt="image" src="https://github.com/user-attachments/assets/57257dec-591f-45f6-bc93-6a95b35deb2b" />


Closes #145

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
