### PR TITLE
feat: improve style of stock additional information section

### DIFF
--- a/mason/stock/stockprops.mas
+++ b/mason/stock/stockprops.mas
@@ -59,8 +59,37 @@ my $prop_select = simple_selectbox_html(
 
 </%perl>
 
-<div id="<% $div_name %>_content">
-</div>
+<style>
+    #<% $div_name %>_content > tr > td {
+        padding-right: var(--padding-lg);
+        vertical-align: middle;
+    }
+    .stockprop-pill {
+        display: inline-block;
+        background-color: var(--gray-100);
+        color: var(--text-color);
+        padding: var(--padding-sm) var(--padding-lg);
+        border-radius: 15px;
+        margin-right: var( --padding-md);
+        margin-bottom: var(--padding-sm);
+        font-size: var(--font-size-sm);
+    }
+    .stockprop-delete,
+    .stockprop-delete:link {
+        color: var(--red-400);
+        margin-left: var(--padding-md);
+        font-weight: bold;
+        text-decoration: none;
+        line-height: 1;
+    }
+    .stockprop-delete:hover {
+        color: var(--red-500);
+        text-decoration: none;
+    }
+</style>
+
+<table id="<% $div_name %>_content">
+</table>
 
 
 <div class ="modal fade" id="<% $div_name %>_add_dialog" name="<% $div_name %>_add_dialog" tabindex="-1" role="dialog" aria-labelledby="add<% $div_name %>Dialog">
@@ -146,17 +175,19 @@ function <% $div_name %>_renderProps(props) {
       for(var i=0; i<props.length; i++) {
         if (n ===  props[i]['type_name']) {
           var lineStr = props[i]['value'];
+          var deleteLink = '';
           if (jQuery.cookie("sgn_session_id") && edit_privs === 1) {
-            lineStr = lineStr + '[<a href="javascript:<% $div_name %>_deleteProp(\''+props[i]['value']+'\', '+props[i]['stockprop_id']+')">X</a>]';
+            deleteLink = '<a class="stockprop-delete" href="javascript:<% $div_name %>_deleteProp(\''+props[i]['value']+'\', '+props[i]['stockprop_id']+')">&times;</a>';
           }
-	  lines.push(lineStr);
+          lines.push('<span class="stockprop-pill">' + lineStr + deleteLink + '</span>');
         }
 
       }
-      html = html + '<b>'+n+'</b>&nbsp;&nbsp;';
+      html = html + '<tr>';
+      html = html + '<td><b>'+n+'</b></td>';
       //html  = html + lineStr;
-      html = html + lines.join(", ");
-      html = html + '<br />\n';
+      html = html + '<td>' + lines.join(" ") + '</td>';
+      html = html + '</tr>\n';
    }
    jQuery('#<% $div_name %>_content').html(html);
 

--- a/t/selenium2/stock/stock_detail.t
+++ b/t/selenium2/stock/stock_detail.t
@@ -63,7 +63,7 @@ $t->while_logged_in_as("submitter", sub {
     $t->accept_alert();
     $t->wait_for_network_idle();
 
-    $t->click_ok('//div[@id="synonyms_content"]/a[text() = "X"]', "xpath", "find delete synonym link");
+    $t->click_ok('//*[@id="synonyms_content"]//a[contains(@class, "stockprop-delete")]', "xpath", "find delete synonym link");
 
     $t->accept_alert_ok('accept alert');
     $t->accept_alert_ok('accept alert');


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

The Synonyms and Additional Information sections (both sharing the stockprops.mas template) have been restyled into a table with grey pills surrounding the property values.



|Before|After|
|-|-|
|<img width="490" height="247" alt="image" src="https://github.com/user-attachments/assets/3d889490-b12b-44a6-9a6c-96453c6e0747" />|<img width="612" height="347" alt="image" src="https://github.com/user-attachments/assets/2b61de10-f119-4d2e-b086-37bb3b839800" />|


Closes #27 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
