### PR TITLE
search: enable stock results datatable state save

### DIFF
--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -795,6 +795,7 @@ function _load_stock_search_results(stock_type, editable_stockprops_search, stoc
                 alert("Error retrieving search results: ", response);
             },
         },
+        'stateSave': true,
         'colReorder': true,
         'dom': 'lBfrtip',
         'rowId': 'Stock Id',


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

DataTables has a built-in feature to persist state such as the column order to local/session storage (so it restores on reload) but it has to be enabled.

That the header cells maintained their order despite this feature being off is likely a bug / undefined behaviour. Nevertheless, enabling stateSave fixes the issue.

Closes #134


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
