### PR TITLE
search: organism and synonyms columns are now user-toggleable

### DIFF
--- a/lib/SGN/Controller/AJAX/Search/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Search/Stock.pm
@@ -119,11 +119,17 @@ sub stock_search :Path('/ajax/search/stocks') Args(0) {
             }
 
             # Start the row with Stock Id first, then the name link, etc.
-            my @return_row = ( $stock_id, $name_link, $type, $organism, $synonym_string );
+            my @return_row = ( $stock_id, $name_link, $type );
 
             # Append extra stockprop columns in the exact order requested by the client
             foreach my $property (@$stockprop_columns_view_array){
-                push @return_row, $_->{$property};
+                if ($property eq 'organism') {
+                    push @return_row, $organism;
+                } elsif ($property eq 'synonyms') {
+                    push @return_row, $synonym_string;
+                } else {
+                    push @return_row, $_->{$property};
+                }
             }
 
             push @return, \@return_row;

--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -309,8 +309,6 @@ my $breeding_programs_select = simple_selectbox_html(
                     <th>Stock Id</th>
                     <th>Stock Name</th>
                     <th>Stock Type</th>
-                    <th>Organism</th>
-                    <th>Synonyms</th>
                     <th>Organization</th>
                 </tr>
                 </thead>
@@ -515,7 +513,7 @@ jQuery(document).ready(function () {
     let stockprop_extra_columns_view_array = [ 'organization' ];
 
     function updateResultsHeader() {
-      const table_colnames = ["Stock Id", "Stock Name", "Stock Type", "Organism", "Synonyms"];
+      const table_colnames = ["Stock Id", "Stock Name", "Stock Type"];
       for (let i = 0; i < stockprop_extra_columns_view_array.length; i++) {
         table_colnames.push(stockprop_extra_columns_view_array[i]);
       }

--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -71,6 +71,11 @@ my $breeding_programs_select = simple_selectbox_html(
     choices => $breeding_programs,
     id      => "breeding_program" ,
 );
+
+# View columns are the configured editable stock props merged with "organism" and "synonyms"
+# which appear in the View Another Property dropdown but are handled as special cases
+my @view_column_options = (@{ $editable_stock_props || [] }, 'organism', 'synonyms');
+@view_column_options = sort { "\L$a" cmp "\L$b" } @view_column_options;
 </%perl>
 
 <&| /page/info_section.mas, title => 'Search', collapsible=>1, collapsed=>0 &>
@@ -283,7 +288,7 @@ my $breeding_programs_select = simple_selectbox_html(
               <div class="input-group">
                 <span class="input-group-btn">
                   <select class="form-control" id="editable_stockprop_view_column_term" name="editable_stockprop_view_column_term">
-%  foreach my $stockprop (sort { "\L$a" cmp "\L$b" } @$editable_stock_props){
+%  foreach my $stockprop (@view_column_options){
                     <option title="<% $stockprop %>" value="<% $stockprop %>" ><% $stockprop %></option>
 %  }
                   </select>

--- a/t/unit_mech/AJAX/Search/Stock.t
+++ b/t/unit_mech/AJAX/Search/Stock.t
@@ -104,8 +104,8 @@ $mech->post_ok(
     'http://localhost:3010/ajax/search/stocks',
     [
         'length'=>10, 'start'=>0,
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ],
     "basic stock search test"
 );
@@ -144,8 +144,8 @@ $mech->post_ok(
         "any_name_matchtype" => "contains",
         "any_name" => "test",
         "stock_type"=>'accession',
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ],
     "search accession test"
 );
@@ -178,8 +178,8 @@ $mech->post_ok(
         "any_name_matchtype" => "contains",
         "any_name" => "test",
         "stock_type"=>"plot",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ],
     "search plot test"
 
@@ -213,8 +213,8 @@ $mech->post_ok(
         "any_name_matchtype" => "contains",
         "any_name" => "test",
         "stock_type"=>"cross",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ],
     "stock search test with cross"
 );
@@ -247,8 +247,8 @@ $mech->post_ok(
         "any_name_matchtype" => "contains",
         "any_name" => "test",
         "stock_type"=>"population",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ]
 );
 $response = decode_json $mech->content;
@@ -275,8 +275,8 @@ $mech->post_ok(
         "any_name_matchtype" => "starts_with",
         "any_name" => "test5",
         "stock_type"=>"accession",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ]
 );
 $response = decode_json $mech->content;
@@ -304,8 +304,8 @@ $mech->post_ok(
         "any_name" => "001",
         "stock_type"=>"accession",
         "trait"=>"fresh root weight",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ]
 );
 $response = decode_json $mech->content;
@@ -332,8 +332,8 @@ $mech->post_ok(
         "any_name" => "g",
         "stock_type"=>"accession",
         "breeding_program" => $test_bp_id,
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ],
     "test search any type contains"
 );
@@ -367,8 +367,8 @@ $mech->post_ok(
         "any_name" => "t",
         "stock_type"=>"accession",
         "project" => "test_trial",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ],
     "test contains with test_trial"
 );
@@ -395,8 +395,8 @@ $mech->post_ok(
         'length'=>10, 'start'=>0,
         "stock_type"=>"accession",
         "year" => "2014",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ]
 );
 $response = decode_json $mech->content;
@@ -430,8 +430,8 @@ $mech->post_ok(
         "stock_type"=>"accession",
         "breeding_program" => $test_bp_id,
         "location"=>"test_location",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ]
 );
 $response = decode_json $mech->content;
@@ -464,8 +464,8 @@ $mech->post_ok(
         "any_name" => "t",
         "stock_type"=>"plot",
         "project" => "test_trial",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ]
 );
 $response = decode_json $mech->content;
@@ -496,8 +496,8 @@ $mech->post_ok(
         'length'=>10, 'start'=>0,
         "stock_type"=>"plot",
         "year" => "2014",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ]
 );
 $response = decode_json $mech->content;
@@ -530,8 +530,8 @@ $mech->post_ok(
         "any_name" => "g",
         "stock_type"=>"plot",
         "breeding_program" => $test_bp_id,
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ]
 );
 $response = decode_json $mech->content;
@@ -562,8 +562,8 @@ $mech->post_ok(
         'length'=>10, 'start'=>0,
         "stock_type"=>"plot",
         "location"=>"test_location",
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ]
 );
 $response = decode_json $mech->content;
@@ -599,7 +599,11 @@ print STDERR "CONTENTS: ".$mech->content;
 $response = decode_json $mech->content;
 print STDERR "AFTER ORGANIZATION ADD: ". Dumper $response;
 
-$mech->post_ok('http://localhost:3010/ajax/search/stocks',["editable_stockprop_values" => encode_json({"organization"=>{"matchtype"=>"contains", "value"=>"organization_name_1"}})] );
+$mech->post_ok('http://localhost:3010/ajax/search/stocks',[
+    "editable_stockprop_values" => encode_json({"organization"=>{"matchtype"=>"contains", "value"=>"organization_name_1"}}),
+    "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1}),
+    "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms"])
+] );
 $response = decode_json $mech->content;
 $response = _fix_response_links($response);
 print STDERR Dumper $response;
@@ -617,8 +621,8 @@ $mech->post_ok(
     'http://localhost:3010/ajax/search/stocks',
     [
         "editable_stockprop_values"         => encode_json({"organization"=>{"matchtype"=>"contains", "value"=>"organization_name_1"}}),
-        "extra_stockprop_columns_view"      => encode_json({"organization"=>1}),
-        "stockprop_extra_columns_view_array"=> encode_json(["organization"])
+        "extra_stockprop_columns_view"      => encode_json({"organism"=>1, "synonyms"=>1, "organization"=>1}),
+        "stockprop_extra_columns_view_array"=> encode_json(["organism", "synonyms", "organization"])
     ]
 );
 $response = decode_json $mech->content;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Removes the organism and synonyms columns from the default stock search results table:
<img width="1526" height="332" alt="image" src="https://github.com/user-attachments/assets/5eaf77c4-d370-4299-ac73-458b8496238b" />

The columns can be added back with the "View Another Property" dropdown:
<img width="1586" height="579" alt="image" src="https://github.com/user-attachments/assets/829d04ba-d30f-4129-b072-571ccfddeb8f" />
<img width="1556" height="349" alt="image" src="https://github.com/user-attachments/assets/ee1bf609-539f-4983-8abb-43275c96a1b4" />


Closes #105


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
