### PR TITLE
fix(fieldmap): handle "Download Spatial Layout" button click

### DIFF
--- a/js/source/entries/fieldmap_react.tsx
+++ b/js/source/entries/fieldmap_react.tsx
@@ -359,6 +359,19 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
     }, [activeTrialIds]);
 
     useEffect(() => {
+        const handleExternalClick = (e: MouseEvent) => {
+            const target = e.target as HTMLElement | null;
+            if (target && (target.id === 'trial_fieldmap_download_layout_button' || target.closest('#trial_fieldmap_download_layout_button'))) {
+                setShowDownloadCSVModal(true);
+            }
+        };
+        document.addEventListener('click', handleExternalClick);
+        return () => {
+            document.removeEventListener('click', handleExternalClick);
+        };
+    }, []);
+
+    useEffect(() => {
         fetch(`/ajax/breeders/trial/${trialId}/controls`)
             .then(res => res.json())
             .then(response => {
@@ -1328,7 +1341,7 @@ const FieldMapContainer: React.FC<FieldMapContainerProps> = ({
                 cellVal += (cellVal ? '\n' : '') + plot.additionalInfo?.familyName;
             }
             if (csvDownloadOpts.crossName && plot.crossName) {
-                cellVal += (cellVal ? '\n' : '') + plot.additionalInfo?.crossName;
+                cellVal += (cellVal ? '\n' : '') + plot.crossName;
             }
 
             coord_matrix[r][c] = `"${cellVal}"`;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR fixes the "Download Spatial Layout" button in fieldmap.

- Added a document-level listener to bridge clicks from the Mason-rendered "Download Spatial Layout" button (#trial_fieldmap_download_layout_button) into React to trigger the download customizer modal.
- Fixed a typo where cross names were incorrectly queried from `plot.additionalInfo?.crossName` instead of `plot.crossName`.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
