### PR TITLE
feat(stocks): centralize change logging in audit log, remove "Stock Editors" section

### DIFF
--- a/cgi-bin/phenome/stock/stock_ajax_form.pl
+++ b/cgi-bin/phenome/stock/stock_ajax_form.pl
@@ -86,9 +86,10 @@ sub store {
     if ($message) {
         $error = " Stock $args{uniquename}  already exists in the database ";
     }else {
-        try{
-            $self->SUPER::store(); #this sets $json_hash{validate} if the form validation failed.
-            $stock_id = $stock->stock_id() ;
+        try {
+            if (!$self->SUPER::store()) {
+                $stock_id = $stock->stock_id() ;
+            }
         } catch {
             $error = " An error occurred. Cannot store to the database\n An  email message has been sent to the SGN development team";
             CXGN::Contact::send_email('stock_ajax_form.pl died', $error . "\n" . $_ , 'sgn-bugs@sgn.cornell.edu');
@@ -114,8 +115,10 @@ sub store {
 sub delete {
     ##Delete the stock (actually set obsolete = 't')
     my $self = shift;
-    my $check = $self->check_modify_privileges();
-    $self->print_json() if $check ; #error or no user privileges
+    if ($self->check_modify_privileges()) {
+        $self->print_json();
+        return;
+    }
 
     my $stock      = $self->get_object();
     my $stock_name = $stock->uniquename();

--- a/lib/CXGN/Page/Form/AjaxFormPage.pm
+++ b/lib/CXGN/Page/Form/AjaxFormPage.pm
@@ -48,7 +48,7 @@ use strict;
 use warnings;
 use Carp;
 
-use CXGN::Tools::Text qw | sanitize_string |;
+use CXGN::Tools::Text qw|sanitize_string|;
 
 use CXGN::Page::Form::Static;
 use CXGN::Page::Form::Editable;
@@ -67,7 +67,7 @@ use CXGN::Feed;
 use JSON;
 use YAML;
 
-use base qw /CXGN::Debug/ ;
+use base qw/CXGN::Debug/;
 =head2 new
 
  Usage:        my $s = CXGN::Page::SimpleFormPageSubClass->new();
@@ -96,18 +96,18 @@ sub new {
     __PACKAGE__->SUPER::new();
 
     my $dbh = CXGN::DB::Connection->new();
-    $self->set_ajax_page(CXGN::Scrap::AjaxPage->new() );
+    $self->set_ajax_page(CXGN::Scrap::AjaxPage->new());
 
     $self->{is_owner} = 0;
     $self->set_dbh($dbh);
 
     $self->set_login(CXGN::Login->new($self->get_dbh()));
     my %args = $self->get_ajax_page()->get_all_encoded_arguments("<>&\";"); ##
-    my %json_hash=();
+    my %json_hash = ();
     # sanitize the inputs, we don't want to end up like bobby tables school.
     #
-    foreach my $k (keys (%args)) {
-    	$args{$k} = CXGN::Tools::Text::sanitize_string($args{$k});
+    foreach my $k (keys(%args)) {
+        $args{$k} = CXGN::Tools::Text::sanitize_string($args{$k});
     }
 
     $self->set_args(%args);
@@ -117,39 +117,38 @@ sub new {
     $self->set_action($args{action});
 
     if (!$self->get_action()) {
-	$self->set_action("view");
+        $self->set_action("view");
     }
-    if (!$self->get_object_id && !$args{action} ) {
+    if (!$self->get_object_id && !$args{action}) {
         $self->set_action("new");
     }
-    if (!$self->get_object_id() && $self->get_action()!~/new|store|confirm_store/) {
-	$json_hash{error}='No identifier provided to display data of this page for action view.';
-
+    if (!$self->get_object_id() && $self->get_action() !~ /new|store|confirm_store/) {
+        $json_hash{error} = 'No identifier provided to display data of this page for action view.';
     }
     else {
-	if ($self->get_action()!~/new|view|edit|store|delete|confirm_delete|confirm_store/) {
-	    $json_hash{error}='No identifier provided';
-	}
+        if ($self->get_action() !~ /new|view|edit|store|delete|confirm_delete|confirm_store/) {
+            $json_hash{error} = 'No identifier provided';
+        }
     }
 
     if ($self->get_action() eq "view") {
- 	$self->view();
+        $self->view();
     }
     elsif ($self->get_action() eq "edit") {
- 	$self->edit();
+        $self->edit();
     }
     elsif ($self->get_action() eq "new") {
-	$self->set_object_id(0);
-	my %args = $self->get_args();
-	$args{$self->get_primary_key()}=0;
-	$self->set_args(%args);
-	$self->add();
+        $self->set_object_id(0);
+        my %args = $self->get_args();
+        $args{$self->get_primary_key()} = 0;
+        $self->set_args(%args);
+        $self->add();
     }
     elsif ($self->get_action() eq "store") {
- 	$self->store();
+        $self->store();
     }
     elsif ($self->get_action() eq "confirm_delete") {
-	$self->delete();
+        $self->delete();
     }
     ##action delete is being handled by the JSFormPage javascript object
 
@@ -183,15 +182,15 @@ sub new {
 
 sub check_modify_privileges {
     my $self = shift;
-    my %json_hash= $self->get_json_hash();
+    my %json_hash = $self->get_json_hash();
     # implement quite strict access controls by default
     #
-    my ($person_id, $user_type)=$self->get_login()->has_session();
+    my ($person_id, $user_type) = $self->get_login()->has_session();
     $user_type ||= '';
 
     if ($user_type eq 'curator') {
         $self->set_is_owner(1);
-	return 0;
+        return 0;
     }
     if (!$person_id) {
         $json_hash{login} = 1;
@@ -200,20 +199,22 @@ sub check_modify_privileges {
     }
 
     if ($user_type !~ /submitter|sequencer|curator/) {
-        if (!$json_hash{error} ) {
-	    $json_hash{error} = "You must have an account of type submitter to be able to submit data. Please contact SGN to change your account type."; }
-	$self->set_json_hash(%json_hash);
-	return 1;
+        if (!$json_hash{error}) {
+            $json_hash{error} = "You must have an account of type submitter to be able to submit data. Please contact SGN to change your account type.";
+        }
+        $self->set_json_hash(%json_hash);
+        return 1;
     }
     my @owners = $self->get_owners();
 
-    if ((@owners) && (!(grep { $_ =~ /^$person_id$/ } @owners) )) {
-	# check the owner only if the action is not new
-	#
-	$json_hash{error} = "You do not have rights to modify this database entry because you do not own it. [$person_id, @owners]";
+    if ((@owners) && (!(grep {$_ =~ /^$person_id$/} @owners))) {
+        # check the owner only if the action is not new
+        #
+        $json_hash{error} = "You do not have rights to modify this database entry because you do not own it. [$person_id, @owners]";
         $self->set_json_hash(%json_hash);
         return 1;
-    } else {  $self->set_is_owner(1); }
+    }
+    else {$self->set_is_owner(1);}
 
     # override to check privileges for edit, store, delete.
     # return 0 for allow, 1 for not allow.
@@ -242,7 +243,7 @@ sub check_modify_privileges {
 sub define_object {
     my $self = shift;
 
-    my %json_hash= $self->get_json_hash();
+    my %json_hash = $self->get_json_hash();
     # in the subclass, instantiate your object here and  call
     $self->set_object();
     $self->set_object_id();
@@ -250,10 +251,10 @@ sub define_object {
     $self->set_primary_key();
     $self->set_owners();
 
-    if ( $self->get_object()->get_obsolete() eq 't' ) {
-	$json_hash{error} = "Object is obsolete!";
-	$self->set_json_hash(%json_hash);
-	$self->print_json();
+    if ($self->get_object()->get_obsolete() eq 't') {
+        $json_hash{error} = "Object is obsolete!";
+        $self->set_json_hash(%json_hash);
+        $self->print_json();
     }
 }
 
@@ -305,7 +306,7 @@ sub add {
 sub store {
     my $self = shift;
     my $dont_show_form = shift;
-    my %json_hash= $self->get_json_hash();
+    my %json_hash = $self->get_json_hash();
     if ($self->check_modify_privileges()) {
         return 1;
     }
@@ -318,37 +319,36 @@ sub store {
     # validate the form
     my %errors = $self->get_form()->validate($self->get_args());
     if (!%errors) {
+        #give the user the opportunity to modify, add or remove form parameters before committing them
+        #(this needs to be done after validate() because that assumes it'll have the parameters given on the form as displayed)
+        $self->validate_parameters_before_store();
 
-	#give the user the opportunity to modify, add or remove form parameters before committing them
-	#(this needs to be done after validate() because that assumes it'll have the parameters given on the form as displayed)
-	$self->validate_parameters_before_store();
+        # the form validated. Now let's check if it passes the uniqueness
+        # constraints.
 
-	# the form validated. Now let's check if it passes the uniqueness
-	# constraints.
+        $self->d("**** about to call the get_form->store() ****");
+        $self->get_form()->store($self->get_args());
 
-	$self->d("**** about to call the get_form->store() ****");
-	$self->get_form()->store($self->get_args());
-
-	#give the user the opportunity to do anything related to the form after storing
-	$self->process_parameters_after_store();
+        #give the user the opportunity to do anything related to the form after storing
+        $self->process_parameters_after_store();
 
         # was it an insert? get the insert id
-	#
-	if (!$self->get_object_id()) {
-	    my $id = $self->get_form()->get_insert_id();
-	    $self->set_object_id($id);
-	}
+        #
+        if (!$self->get_object_id()) {
+            my $id = $self->get_form()->get_insert_id();
+            $self->set_object_id($id);
+        }
         return 0;
     }
     else {
-	# if there was an error, re-display the same forms.
-	# the errors will be displayed on the page for each
-	# field that did not validate.
-	#
-	$json_hash{validate} = 1;
-	$json_hash{html} = $self->get_form()->as_table_string();
-	$self->set_json_hash(%json_hash);
-	#$self->print_json(); #json is printed from the sub-class regardless of the content
+        # if there was an error, re-display the same forms.
+        # the errors will be displayed on the page for each
+        # field that did not validate.
+        #
+        $json_hash{validate} = 1;
+        $json_hash{html} = $self->get_form()->as_table_string();
+        $self->set_json_hash(%json_hash);
+        #$self->print_json(); #json is printed from the sub-class regardless of the content
         return 1;
     }
 }
@@ -386,9 +386,9 @@ sub view {
 =cut
 
 sub get_user {
-  my $self=shift;
-  my $person_id = $self->get_login()->has_session();
-  return CXGN::People::Person->new($self->get_dbh(), $person_id);
+    my $self = shift;
+    my $person_id = $self->get_login()->has_session();
+    return CXGN::People::Person->new($self->get_dbh(), $person_id);
 }
 
 =head2 generate_form
@@ -407,9 +407,9 @@ sub get_user {
 
 sub generate_form {
     my $self = shift;
-    my $error=  "Please subclass 'generate_form' function!\n";
+    my $error = "Please subclass 'generate_form' function!\n";
     warn $error;
-    my %json_hash=$self->get_json_hash();
+    my %json_hash = $self->get_json_hash();
     $json_hash{error} = $error;
     $self->set_json_hash(%json_hash);
     $self->print_json();
@@ -433,8 +433,8 @@ sub delete {
     my $self = shift;
     warn "Override 'delete' function in derived class\n";
 
-    my $error="Deleting is not implemented for this object. Override 'delete' function in derived class.";
-    my %json_hash=$self->get_json_hash();
+    my $error = "Deleting is not implemented for this object. Override 'delete' function in derived class.";
+    my %json_hash = $self->get_json_hash();
     $json_hash{error} = $error;
     $self->set_json_hash(%json_hash);
     $self->print_json;
@@ -457,12 +457,12 @@ sub delete {
 =cut
 
 sub display_form {
-    my $self=shift;
-    my %json_hash= $self->get_json_hash();
+    my $self = shift;
+    my %json_hash = $self->get_json_hash();
     # edit links are printed from the javascript object! See JSFormPage.js
     #print $self->get_edit_links();
 
-    if (!($json_hash{html}) ) { $json_hash{html} = $self->get_form()->as_table_string() ; }
+    if (!($json_hash{html})) {$json_hash{html} = $self->get_form()->as_table_string();}
     $self->check_modify_privileges();
 
     $json_hash{"user_type"} = $self->get_user()->get_user_type();
@@ -489,14 +489,14 @@ sub display_form {
 =cut
 
 sub get_ajax_page {
-  my $self=shift;
-  return $self->{ajax_page};
+    my $self = shift;
+    return $self->{ajax_page};
 
 }
 
 sub set_ajax_page {
-  my $self=shift;
-  $self->{ajax_page}=shift;
+    my $self = shift;
+    $self->{ajax_page} = shift;
 }
 
 =head2 get_dbh
@@ -513,14 +513,14 @@ sub set_ajax_page {
 =cut
 
 sub get_dbh {
-  my $self=shift;
-  return $self->{dbh};
+    my $self = shift;
+    return $self->{dbh};
 
 }
 
 sub set_dbh {
-  my $self=shift;
-  $self->{dbh}=shift;
+    my $self = shift;
+    $self->{dbh} = shift;
 }
 
 =head2 get_login
@@ -537,14 +537,14 @@ sub set_dbh {
 =cut
 
 sub get_login {
-  my $self=shift;
-  return $self->{login};
+    my $self = shift;
+    return $self->{login};
 
 }
 
 sub set_login {
-  my $self=shift;
-  $self->{login}=shift;
+    my $self = shift;
+    $self->{login} = shift;
 }
 
 =head2 get_args
@@ -561,15 +561,15 @@ sub set_login {
 =cut
 
 sub get_args {
-  my $self=shift;
-  if (!$self->{args}) { %{$self->{args}} = (); }
-  return %{$self->{args}};
+    my $self = shift;
+    if (!$self->{args}) {%{$self->{args}} = ();}
+    return %{$self->{args}};
 
 }
 
 sub set_args {
-  my $self=shift;
-  %{$self->{args}}=@_;
+    my $self = shift;
+    %{$self->{args}} = @_;
 }
 
 
@@ -587,14 +587,14 @@ sub set_args {
 =cut
 
 sub get_object {
-  my $self=shift;
-  return $self->{object};
+    my $self = shift;
+    return $self->{object};
 
 }
 
 sub set_object {
-  my $self=shift;
-  $self->{object}=shift;
+    my $self = shift;
+    $self->{object} = shift;
 }
 
 =head2 accessors get_object_name, set_object_name
@@ -608,13 +608,13 @@ sub set_object {
 =cut
 
 sub get_object_name {
-  my $self = shift;
-  return $self->{object_name};
+    my $self = shift;
+    return $self->{object_name};
 }
 
 sub set_object_name {
-  my $self = shift;
-  $self->{object_name} = shift;
+    my $self = shift;
+    $self->{object_name} = shift;
 }
 
 
@@ -635,14 +635,14 @@ sub set_object_name {
 =cut
 
 sub get_owners {
-  my $self=shift;
-  return @{$self->{owners}};
+    my $self = shift;
+    return @{$self->{owners}};
 
 }
 
 sub set_owners {
-  my $self=shift;
-  @{$self->{owners}}=@_;
+    my $self = shift;
+    @{$self->{owners}} = @_;
 }
 
 =head2 get_action, set_action
@@ -660,14 +660,14 @@ sub set_owners {
 =cut
 
 sub get_action {
-  my $self=shift;
-  return $self->{action};
+    my $self = shift;
+    return $self->{action};
 
 }
 
 sub set_action {
-  my $self=shift;
-  $self->{action}=shift;
+    my $self = shift;
+    $self->{action} = shift;
 }
 
 
@@ -683,15 +683,14 @@ sub set_action {
 =cut
 
 sub get_primary_key {
-  my $self=shift;
-  return $self->{primary_key};
+    my $self = shift;
+    return $self->{primary_key};
 
 }
 
-
 sub set_primary_key {
-  my $self=shift;
-  $self->{primary_key}=shift;
+    my $self = shift;
+    $self->{primary_key} = shift;
 }
 
 =head2 get_script_name, set_script_name
@@ -707,20 +706,20 @@ sub set_primary_key {
 =cut
 
 sub get_script_name {
-    my $self=shift;
+    my $self = shift;
     if (!exists($self->{script_name})) {
-	#return CXGN::Apache::Request::page_name();
-	return $ENV{SCRIPT_NAME};
+        #return CXGN::Apache::Request::page_name();
+        return $ENV{SCRIPT_NAME};
     }
     else {
-	return $self->{script_name};
+        return $self->{script_name};
     }
 
 }
 
 sub set_script_name {
-    my $self=shift;
-    $self->{script_name}=shift;
+    my $self = shift;
+    $self->{script_name} = shift;
 }
 
 =head2 get_object_id, set_object_id
@@ -735,14 +734,14 @@ sub set_script_name {
 =cut
 
 sub get_object_id {
-  my $self=shift;
-  return $self->{object_id};
+    my $self = shift;
+    return $self->{object_id};
 
 }
 
 sub set_object_id {
-  my $self=shift;
-  $self->{object_id}=shift;
+    my $self = shift;
+    $self->{object_id} = shift;
 }
 
 =head2 get_form, set_form
@@ -762,15 +761,15 @@ sub set_object_id {
 =cut
 
 sub get_form {
-  my $self=shift;
+    my $self = shift;
 
-  return $self->{form};
+    return $self->{form};
 
 }
 
 sub set_form {
-  my $self=shift;
-  $self->{form}=shift;
+    my $self = shift;
+    $self->{form} = shift;
 }
 
 =head2 accessors get_json_hash, set_json_hash
@@ -801,15 +800,15 @@ sub set_form {
 =cut
 
 sub get_json_hash {
-  my $self=shift;
-  if (!$self->{json_hash}) { %{$self->{json_hash}} = (); }
-  return %{$self->{json_hash}};
+    my $self = shift;
+    if (!$self->{json_hash}) {%{$self->{json_hash}} = ();}
+    return %{$self->{json_hash}};
 
 }
 
 sub set_json_hash {
-  my $self=shift;
-  %{$self->{json_hash}}=@_;
+    my $self = shift;
+    %{$self->{json_hash}} = @_;
 }
 
 =head2 accessors get_is_owner, set_is_owner
@@ -823,13 +822,13 @@ sub set_json_hash {
 =cut
 
 sub get_is_owner {
-  my $self = shift;
-  return $self->{is_owner};
+    my $self = shift;
+    return $self->{is_owner};
 }
 
 sub set_is_owner {
-  my $self = shift;
-  $self->{is_owner} = shift;
+    my $self = shift;
+    $self->{is_owner} = shift;
 }
 
 =head2 init_form
@@ -849,14 +848,16 @@ sub init_form {
     my $self = shift;
     my $form_id = shift;
 
-    if ($self->get_action() =~/edit|^store|new/) {
-	$self->set_form( CXGN::Page::Form::Editable -> new({no_buttons=>1, form_id=>$form_id} ) ) ;
+    if ($self->get_action() =~ /edit|^store|new/) {
+        $self->set_form(CXGN::Page::Form::Editable->new({ no_buttons => 1, form_id => $form_id }));
 
-    }elsif ($self->get_action() =~/confirm_store/) {
-	$self->set_form( CXGN::Page::Form::ConfirmStore->new() ) ;
+    }
+    elsif ($self->get_action() =~ /confirm_store/) {
+        $self->set_form(CXGN::Page::Form::ConfirmStore->new());
 
-    }else  {
-	$self->set_form( CXGN::Page::Form::Static -> new() );
+    }
+    else {
+        $self->set_form(CXGN::Page::Form::Static->new());
     }
 
 }
@@ -874,14 +875,14 @@ sub init_form {
 =cut
 
 sub get_request {
-  my $self=shift;
-  return $self->{request};
+    my $self = shift;
+    return $self->{request};
 
 }
 
 sub set_request {
-  my $self=shift;
-  $self->{request}=shift;
+    my $self = shift;
+    $self->{request} = shift;
 }
 
 =head2 validate_parameters_before_store
@@ -931,11 +932,11 @@ sub process_parameters_after_store {
 
 
 sub print_json {
-    my $self=shift;
-    my %results= $self->get_json_hash();
+    my $self = shift;
+    my %results = $self->get_json_hash();
 
-    if ($results{die_error} ) {
-        CXGN::Contact::send_email('AjaxFormPage died',$results{"error"} );
+    if ($results{die_error}) {
+        CXGN::Contact::send_email('AjaxFormPage died', $results{"error"});
     }
     my $json = JSON->new();
     #$self->get_ajax_page()->send_http_header();
@@ -960,45 +961,43 @@ sub print_json {
 =cut
 
 sub send_form_email {
-    my $self   = shift;
-    my $opts=shift;
+    my $self = shift;
+    my $opts = shift;
     $opts ||= {};
-    my $subject=$opts->{subject};
+    my $subject = $opts->{subject};
     my $mailing_list = $opts->{mailing_list};
     my $refering_page_link = $opts->{refering_page};
     my $action = $opts->{action};
 
-    my $user=$self->get_user();
+    my $user = $self->get_user();
 
     my $object_id = $self->get_object_id();
 
     my $username =
         $user->get_first_name() . " "
-	. $user->get_last_name();
+            . $user->get_last_name();
     my $sp_person_id = $user->get_sp_person_id();
 
-
     my $user_link =
-	qq |http://www.sgn.cornell.edu/solpeople/personal-info.pl?sp_person_id=$sp_person_id|;
+        qq|http://www.sgn.cornell.edu/solpeople/personal-info.pl?sp_person_id=$sp_person_id|;
 
     my $usermail = $user->get_private_email();
     my $fdbk_body;
-    if ( $action eq 'delete' ) {
+    if ($action eq 'delete') {
         $fdbk_body =
-	    "$username ($user_link) has obsoleted " . $self->get_object_name() . "  $object_id ($refering_page_link) \n  $usermail";
+            "$username ($user_link) has obsoleted " . $self->get_object_name() . "  $object_id ($refering_page_link) \n  $usermail";
     }
-    elsif ( $object_id == 0 ) {
+    elsif ($object_id == 0) {
         $fdbk_body =
-	    "$username ($user_link) has submitted a new ". $self->get_object_name()  . "   \n$usermail ";
+            "$username ($user_link) has submitted a new " . $self->get_object_name() . "   \n$usermail ";
     }
     else {
         $fdbk_body =
-	    "$username ($user_link) has submitted data for " . $self->get_object_name() ." ($refering_page_link) \n $usermail";
+            "$username ($user_link) has submitted data for " . $self->get_object_name() . " ($refering_page_link) \n $usermail";
     }
 
-    CXGN::Contact::send_email( $subject, $fdbk_body,$mailing_list );
-    CXGN::Feed::update_feed( $subject, $fdbk_body );
+    CXGN::Contact::send_email($subject, $fdbk_body, $mailing_list);
+    CXGN::Feed::update_feed($subject, $fdbk_body);
 }
-
 
 1;

--- a/lib/CXGN/Page/Form/AjaxFormPage.pm
+++ b/lib/CXGN/Page/Form/AjaxFormPage.pm
@@ -190,14 +190,20 @@ sub check_modify_privileges {
     $user_type ||= '';
 
     if ($user_type eq 'curator') {
+        $self->set_is_owner(1);
 	return 0;
     }
-    if (!$person_id) { $json_hash{login} = 1 ;  }
+    if (!$person_id) {
+        $json_hash{login} = 1;
+        $self->set_json_hash(%json_hash);
+        return 1;
+    }
+
     if ($user_type !~ /submitter|sequencer|curator/) {
         if (!$json_hash{error} ) {
 	    $json_hash{error} = "You must have an account of type submitter to be able to submit data. Please contact SGN to change your account type."; }
 	$self->set_json_hash(%json_hash);
-	return 0;
+	return 1;
     }
     my @owners = $self->get_owners();
 
@@ -205,12 +211,14 @@ sub check_modify_privileges {
 	# check the owner only if the action is not new
 	#
 	$json_hash{error} = "You do not have rights to modify this database entry because you do not own it. [$person_id, @owners]";
-
+        $self->set_json_hash(%json_hash);
+        return 1;
     } else {  $self->set_is_owner(1); }
 
     # override to check privileges for edit, store, delete.
     # return 0 for allow, 1 for not allow.
     $self->set_json_hash(%json_hash);
+    return 0;
 }
 
 =head2 define_object
@@ -298,7 +306,9 @@ sub store {
     my $self = shift;
     my $dont_show_form = shift;
     my %json_hash= $self->get_json_hash();
-    $self->check_modify_privileges();
+    if ($self->check_modify_privileges()) {
+        return 1;
+    }
 
     # for the store we need a properly formatted form so that we can
     # use its validate and store functions.
@@ -328,6 +338,7 @@ sub store {
 	    my $id = $self->get_form()->get_insert_id();
 	    $self->set_object_id($id);
 	}
+        return 0;
     }
     else {
 	# if there was an error, re-display the same forms.
@@ -338,6 +349,7 @@ sub store {
 	$json_hash{html} = $self->get_form()->as_table_string();
 	$self->set_json_hash(%json_hash);
 	#$self->print_json(); #json is printed from the sub-class regardless of the content
+        return 1;
     }
 }
 

--- a/lib/SGN/Controller/AJAX/Audit.pm
+++ b/lib/SGN/Controller/AJAX/Audit.pm
@@ -80,13 +80,23 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
     my $self = shift;
     my $c = shift;
     my $stock_id = $c->req->param('stock_id');
-    my $q = "SELECT audit_ts, 'stock' AS log_source, operation, username, logged_in_user, before, after, transactioncode, stock_audit_id, is_undo
-        FROM audit.stock_audit
-        WHERE before->>'stock_id' = ? OR after->>'stock_id' = ?
+    my $q = "SELECT a.audit_ts, 'stock' AS log_source, a.operation, a.username, a.logged_in_user, 
+            CASE WHEN c_b.name IS NOT NULL THEN jsonb_set(a.before, '{type_id}', to_jsonb(c_b.name)) ELSE a.before END AS before, 
+            CASE WHEN c_a.name IS NOT NULL THEN jsonb_set(a.after, '{type_id}', to_jsonb(c_a.name)) ELSE a.after END AS after, 
+            a.transactioncode, a.stock_audit_id, a.is_undo
+        FROM audit.stock_audit a
+        LEFT JOIN cvterm c_b ON a.before->>'type_id' = c_b.cvterm_id::text
+        LEFT JOIN cvterm c_a ON a.after->>'type_id' = c_a.cvterm_id::text
+        WHERE a.before->>'stock_id' = ? OR a.after->>'stock_id' = ?
         UNION ALL
-        SELECT audit_ts, 'stockprop' AS log_source, operation, username, logged_in_user, before, after, transactioncode, stockprop_audit_id, is_undo
-        FROM audit.stockprop_audit
-        WHERE before->>'stock_id' = ? OR after->>'stock_id' = ?
+        SELECT a.audit_ts, 'stockprop' AS log_source, a.operation, a.username, a.logged_in_user, 
+            CASE WHEN c_b.name IS NOT NULL THEN jsonb_set(a.before, '{type_id}', to_jsonb(c_b.name)) ELSE a.before END AS before, 
+            CASE WHEN c_a.name IS NOT NULL THEN jsonb_set(a.after, '{type_id}', to_jsonb(c_a.name)) ELSE a.after END AS after, 
+            a.transactioncode, a.stockprop_audit_id, a.is_undo
+        FROM audit.stockprop_audit a
+        LEFT JOIN cvterm c_b ON a.before->>'type_id' = c_b.cvterm_id::text
+        LEFT JOIN cvterm c_a ON a.after->>'type_id' = c_a.cvterm_id::text
+        WHERE a.before->>'stock_id' = ? OR a.after->>'stock_id' = ?
         ORDER BY audit_ts ASC;";
     my $h = $c->dbc->dbh->prepare($q);
     $h->execute($stock_id, $stock_id, $stock_id, $stock_id);

--- a/lib/SGN/Controller/AJAX/Audit.pm
+++ b/lib/SGN/Controller/AJAX/Audit.pm
@@ -79,45 +79,25 @@ sub retrieve_table_names : Path('/ajax/audit/retrieve_table_names'){
 sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
     my $self = shift;
     my $c = shift;
-    my $stock_uniquename = $c->req->param('stock_uniquename');
-    my $q = "SELECT * FROM audit.stock_audit;";
+    my $stock_id = $c->req->param('stock_id');
+    my $q = "SELECT audit_ts, operation, username, logged_in_user, before, after, transactioncode, stock_audit_id, is_undo
+        FROM audit.stock_audit
+        WHERE before->>'stock_id' = ? OR after->>'stock_id' = ?
+        ORDER BY audit_ts ASC;";
     my $h = $c->dbc->dbh->prepare($q);
-    $h->execute();
+    $h->execute($stock_id, $stock_id);
     my @all_audits;
-    my @before;
-    my @after;
-    my $counter = 0;
 
     while (my ($audit_ts, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo) = $h->fetchrow_array) {
-        $after[$counter] = $after;
-        $before[$counter] = $before;
-        $all_audits[$counter] = [$audit_ts, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo];
-        $counter++;
+        # Ensure UTF-8 encoding for text fields to prevent encoding issues
+        $before = defined $before ? Encode::decode('UTF-8', $before, Encode::FB_DEFAULT) : "";
+        $after  = defined $after  ? Encode::decode('UTF-8', $after, Encode::FB_DEFAULT)  : "";
+
+        push @all_audits, [$audit_ts, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo];
     }
 
-    
-    my @matches;
-    for (my $i = 0; $i < $counter; $i++) {
-        my $operation = $all_audits[$i][1];
-        my $stock_json_string;
-
-        eval {
-            my $json_text = ($operation eq "DELETE") ? $before[$i] : $after[$i];
-
-            # Convert Perl Unicode string to UTF-8 encoded bytes before decoding JSON
-            $json_text = Encode::encode('UTF-8', $json_text);
-            $stock_json_string = decode_json($json_text);
-        };
-        if ($@) {
-            warn "Failed to decode JSON at index $i: $@";
-            next; # Skip this iteration in case of error
-        }
-
-        push @matches, $all_audits[$i];
-    }
-
-    my $stock_match_json;
-    $stock_match_json = encode_json(\@matches);
+    my $stock_match_json = encode_json(\@all_audits);
+    utf8::encode($stock_match_json); # Convert to UTF-8 bytes
 
     $c->stash->{rest} = {
         stock_match_after => $stock_match_json,

--- a/lib/SGN/Controller/AJAX/Audit.pm
+++ b/lib/SGN/Controller/AJAX/Audit.pm
@@ -80,7 +80,7 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
     my $self = shift;
     my $c = shift;
     my $stock_id = $c->req->param('stock_id');
-    my $q = "SELECT a.audit_ts, 'stock' AS log_source, a.operation, a.username, p_b.username AS logged_in_username, 
+    my $q = "SELECT a.audit_ts, 'stock' AS log_source, a.operation, p_b.username AS logged_in_username, 
             CASE WHEN c_b.name IS NOT NULL THEN jsonb_set(a.before, '{type}', to_jsonb(c_b.name)) - 'type_id' ELSE a.before END AS before, 
             CASE WHEN c_a.name IS NOT NULL THEN jsonb_set(a.after, '{type}', to_jsonb(c_a.name)) - 'type_id' ELSE a.after END AS after, 
             a.transactioncode, a.stock_audit_id, a.is_undo
@@ -90,7 +90,7 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
         LEFT JOIN sgn_people.sp_person p_b ON a.logged_in_user = p_b.sp_person_id
         WHERE a.before->>'stock_id' = ? OR a.after->>'stock_id' = ?
         UNION ALL
-        SELECT a.audit_ts, 'stockprop' AS log_source, a.operation, a.username, p_p.username AS logged_in_username, 
+        SELECT a.audit_ts, 'stockprop' AS log_source, a.operation, p_p.username AS logged_in_username, 
             CASE WHEN c_b.name IS NOT NULL THEN jsonb_set(a.before, '{type}', to_jsonb(c_b.name)) - 'type_id' ELSE a.before END AS before, 
             CASE WHEN c_a.name IS NOT NULL THEN jsonb_set(a.after, '{type}', to_jsonb(c_a.name)) - 'type_id' ELSE a.after END AS after, 
             a.transactioncode, a.stockprop_audit_id, a.is_undo
@@ -105,12 +105,12 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
     $h->execute($stock_id, $stock_id, $stock_id, $stock_id);
     my @all_audits;
 
-    while (my ($audit_ts, $log_source, $operation, $username, $logged_in_username, $before, $after, $transactioncode, $primary_key, $is_undo) = $h->fetchrow_array) {
+    while (my ($audit_ts, $log_source, $operation, $logged_in_username, $before, $after, $transactioncode, $primary_key, $is_undo) = $h->fetchrow_array) {
         # Ensure UTF-8 encoding for text fields to prevent encoding issues
         $before = defined $before ? Encode::decode('UTF-8', $before, Encode::FB_DEFAULT) : "";
         $after  = defined $after  ? Encode::decode('UTF-8', $after, Encode::FB_DEFAULT)  : "";
 
-        push @all_audits, [$audit_ts, $log_source, $operation, $username, $logged_in_username // '', $before, $after, $transactioncode, $primary_key, $is_undo];
+        push @all_audits, [$audit_ts, $log_source, $operation, $logged_in_username // '', $before, $after, $transactioncode, $primary_key, $is_undo];
     }
 
     my $stock_match_json = encode_json(\@all_audits);

--- a/lib/SGN/Controller/AJAX/Audit.pm
+++ b/lib/SGN/Controller/AJAX/Audit.pm
@@ -93,7 +93,7 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
         $before[$counter] = $before;
         $all_audits[$counter] = [$audit_ts, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo];
         $counter++;
-        }
+    }
 
     
     my @matches;
@@ -113,10 +113,7 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
             next; # Skip this iteration in case of error
         }
 
-        my $desired_uniquename = $stock_json_string->{'uniquename'};
-        if ($stock_uniquename eq $desired_uniquename) {
-            push @matches, $all_audits[$i];
-        }
+        push @matches, $all_audits[$i];
     }
 
     my $stock_match_json;

--- a/lib/SGN/Controller/AJAX/Audit.pm
+++ b/lib/SGN/Controller/AJAX/Audit.pm
@@ -80,34 +80,37 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
     my $self = shift;
     my $c = shift;
     my $stock_id = $c->req->param('stock_id');
-    my $q = "SELECT a.audit_ts, 'stock' AS log_source, a.operation, a.username, a.logged_in_user, 
+    my $q = "SELECT a.audit_ts, 'stock' AS log_source, a.operation, a.username, p_b.username AS logged_in_username, 
             CASE WHEN c_b.name IS NOT NULL THEN jsonb_set(a.before, '{type}', to_jsonb(c_b.name)) - 'type_id' ELSE a.before END AS before, 
             CASE WHEN c_a.name IS NOT NULL THEN jsonb_set(a.after, '{type}', to_jsonb(c_a.name)) - 'type_id' ELSE a.after END AS after, 
             a.transactioncode, a.stock_audit_id, a.is_undo
         FROM audit.stock_audit a
         LEFT JOIN cvterm c_b ON a.before->>'type_id' = c_b.cvterm_id::text
         LEFT JOIN cvterm c_a ON a.after->>'type_id' = c_a.cvterm_id::text
+        LEFT JOIN sgn_people.sp_person p_b ON a.logged_in_user = p_b.sp_person_id
         WHERE a.before->>'stock_id' = ? OR a.after->>'stock_id' = ?
         UNION ALL
-        SELECT a.audit_ts, 'stockprop' AS log_source, a.operation, a.username, a.logged_in_user, 
+        SELECT a.audit_ts, 'stockprop' AS log_source, a.operation, a.username, p_p.username AS logged_in_username, 
             CASE WHEN c_b.name IS NOT NULL THEN jsonb_set(a.before, '{type}', to_jsonb(c_b.name)) - 'type_id' ELSE a.before END AS before, 
             CASE WHEN c_a.name IS NOT NULL THEN jsonb_set(a.after, '{type}', to_jsonb(c_a.name)) - 'type_id' ELSE a.after END AS after, 
             a.transactioncode, a.stockprop_audit_id, a.is_undo
         FROM audit.stockprop_audit a
         LEFT JOIN cvterm c_b ON a.before->>'type_id' = c_b.cvterm_id::text
         LEFT JOIN cvterm c_a ON a.after->>'type_id' = c_a.cvterm_id::text
+        LEFT JOIN sgn_people.sp_person p_p ON a.logged_in_user = p_p.sp_person_id
         WHERE a.before->>'stock_id' = ? OR a.after->>'stock_id' = ?
         ORDER BY audit_ts ASC;";
+
     my $h = $c->dbc->dbh->prepare($q);
     $h->execute($stock_id, $stock_id, $stock_id, $stock_id);
     my @all_audits;
 
-    while (my ($audit_ts, $log_source, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo) = $h->fetchrow_array) {
+    while (my ($audit_ts, $log_source, $operation, $username, $logged_in_username, $before, $after, $transactioncode, $primary_key, $is_undo) = $h->fetchrow_array) {
         # Ensure UTF-8 encoding for text fields to prevent encoding issues
         $before = defined $before ? Encode::decode('UTF-8', $before, Encode::FB_DEFAULT) : "";
         $after  = defined $after  ? Encode::decode('UTF-8', $after, Encode::FB_DEFAULT)  : "";
 
-        push @all_audits, [$audit_ts, $log_source, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo];
+        push @all_audits, [$audit_ts, $log_source, $operation, $username, $logged_in_username // '', $before, $after, $transactioncode, $primary_key, $is_undo];
     }
 
     my $stock_match_json = encode_json(\@all_audits);

--- a/lib/SGN/Controller/AJAX/Audit.pm
+++ b/lib/SGN/Controller/AJAX/Audit.pm
@@ -113,11 +113,8 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
         push @all_audits, [$audit_ts, $log_source, $operation, $logged_in_username // '', $before, $after, $transactioncode, $primary_key, $is_undo];
     }
 
-    my $stock_match_json = encode_json(\@all_audits);
-    utf8::encode($stock_match_json); # Convert to UTF-8 bytes
-
     $c->stash->{rest} = {
-        stock_match_after => $stock_match_json,
+        stock_match_after => encode_json(\@all_audits)
     }
 };
 

--- a/lib/SGN/Controller/AJAX/Audit.pm
+++ b/lib/SGN/Controller/AJAX/Audit.pm
@@ -80,11 +80,11 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
     my $self = shift;
     my $c = shift;
     my $stock_id = $c->req->param('stock_id');
-    my $q = "SELECT audit_ts, operation, username, logged_in_user, before, after, transactioncode, stock_audit_id, is_undo
+    my $q = "SELECT audit_ts, 'stock' AS log_source, operation, username, logged_in_user, before, after, transactioncode, stock_audit_id, is_undo
         FROM audit.stock_audit
         WHERE before->>'stock_id' = ? OR after->>'stock_id' = ?
         UNION ALL
-        SELECT audit_ts, operation, username, logged_in_user, before, after, transactioncode, stockprop_audit_id, is_undo
+        SELECT audit_ts, 'stockprop' AS log_source, operation, username, logged_in_user, before, after, transactioncode, stockprop_audit_id, is_undo
         FROM audit.stockprop_audit
         WHERE before->>'stock_id' = ? OR after->>'stock_id' = ?
         ORDER BY audit_ts ASC;";
@@ -92,12 +92,12 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
     $h->execute($stock_id, $stock_id, $stock_id, $stock_id);
     my @all_audits;
 
-    while (my ($audit_ts, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo) = $h->fetchrow_array) {
+    while (my ($audit_ts, $log_source, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo) = $h->fetchrow_array) {
         # Ensure UTF-8 encoding for text fields to prevent encoding issues
         $before = defined $before ? Encode::decode('UTF-8', $before, Encode::FB_DEFAULT) : "";
         $after  = defined $after  ? Encode::decode('UTF-8', $after, Encode::FB_DEFAULT)  : "";
 
-        push @all_audits, [$audit_ts, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo];
+        push @all_audits, [$audit_ts, $log_source, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo];
     }
 
     my $stock_match_json = encode_json(\@all_audits);

--- a/lib/SGN/Controller/AJAX/Audit.pm
+++ b/lib/SGN/Controller/AJAX/Audit.pm
@@ -81,8 +81,8 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
     my $c = shift;
     my $stock_id = $c->req->param('stock_id');
     my $q = "SELECT a.audit_ts, 'stock' AS log_source, a.operation, a.username, a.logged_in_user, 
-            CASE WHEN c_b.name IS NOT NULL THEN jsonb_set(a.before, '{type_id}', to_jsonb(c_b.name)) ELSE a.before END AS before, 
-            CASE WHEN c_a.name IS NOT NULL THEN jsonb_set(a.after, '{type_id}', to_jsonb(c_a.name)) ELSE a.after END AS after, 
+            CASE WHEN c_b.name IS NOT NULL THEN jsonb_set(a.before, '{type}', to_jsonb(c_b.name)) - 'type_id' ELSE a.before END AS before, 
+            CASE WHEN c_a.name IS NOT NULL THEN jsonb_set(a.after, '{type}', to_jsonb(c_a.name)) - 'type_id' ELSE a.after END AS after, 
             a.transactioncode, a.stock_audit_id, a.is_undo
         FROM audit.stock_audit a
         LEFT JOIN cvterm c_b ON a.before->>'type_id' = c_b.cvterm_id::text
@@ -90,8 +90,8 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
         WHERE a.before->>'stock_id' = ? OR a.after->>'stock_id' = ?
         UNION ALL
         SELECT a.audit_ts, 'stockprop' AS log_source, a.operation, a.username, a.logged_in_user, 
-            CASE WHEN c_b.name IS NOT NULL THEN jsonb_set(a.before, '{type_id}', to_jsonb(c_b.name)) ELSE a.before END AS before, 
-            CASE WHEN c_a.name IS NOT NULL THEN jsonb_set(a.after, '{type_id}', to_jsonb(c_a.name)) ELSE a.after END AS after, 
+            CASE WHEN c_b.name IS NOT NULL THEN jsonb_set(a.before, '{type}', to_jsonb(c_b.name)) - 'type_id' ELSE a.before END AS before, 
+            CASE WHEN c_a.name IS NOT NULL THEN jsonb_set(a.after, '{type}', to_jsonb(c_a.name)) - 'type_id' ELSE a.after END AS after, 
             a.transactioncode, a.stockprop_audit_id, a.is_undo
         FROM audit.stockprop_audit a
         LEFT JOIN cvterm c_b ON a.before->>'type_id' = c_b.cvterm_id::text

--- a/lib/SGN/Controller/AJAX/Audit.pm
+++ b/lib/SGN/Controller/AJAX/Audit.pm
@@ -83,9 +83,13 @@ sub retrieve_stock_audits : Path('/ajax/audit/retrieve_stock_audits'){
     my $q = "SELECT audit_ts, operation, username, logged_in_user, before, after, transactioncode, stock_audit_id, is_undo
         FROM audit.stock_audit
         WHERE before->>'stock_id' = ? OR after->>'stock_id' = ?
+        UNION ALL
+        SELECT audit_ts, operation, username, logged_in_user, before, after, transactioncode, stockprop_audit_id, is_undo
+        FROM audit.stockprop_audit
+        WHERE before->>'stock_id' = ? OR after->>'stock_id' = ?
         ORDER BY audit_ts ASC;";
     my $h = $c->dbc->dbh->prepare($q);
-    $h->execute($stock_id, $stock_id);
+    $h->execute($stock_id, $stock_id, $stock_id, $stock_id);
     my @all_audits;
 
     while (my ($audit_ts, $operation, $username, $logged_in_user, $before, $after, $transactioncode, $primary_key, $is_undo) = $h->fetchrow_array) {

--- a/lib/SGN/Role/Site/DBIC.pm
+++ b/lib/SGN/Role/Site/DBIC.pm
@@ -20,65 +20,51 @@ requires
   Desc : get a L<DBIx::Class::Schema> with the proper connection
          parameters for the given connection name
   Args : L<DBIx::Class> schema package name,
-         (optional) connection name to use
+         (optional) connection name to use,
+         (optional) sp_person_id to set for database audit triggers
   Ret  : schema object
   Side Effects: dies on failure
 
 =cut
 
 sub dbic_schema {
-    my ( $class, $schema_name, $profile_name, $sp_person_id) = @_;
-    #my $self = shift;
-    #print STDERR "sp_person_id passed to DBIC Schema: $sp_person_id \n";
+    my ( $class, $schema_name, $profile_name, $sp_person_id ) = @_;
+
     $class = ref $class if ref $class;
     $schema_name or croak "must provide a schema package name to dbic_schema";
-    #Class::MOP::load_class( $schema_name );
     load_class( $schema_name );
     state %schema_cache;
-    
-    return $schema_cache{$class}{$profile_name || ''}{$schema_name} ||= do {
+
+    my $schema = $schema_cache{$class}{$profile_name || ''}{$schema_name} ||= do {
         my $profile = $class->dbc_profile( $profile_name );
-        #print STDERR "profile: ".Dumper($profile)."\n";
-        #my $sp_person_id = $profile -> user -> get_object() -> get_sp_person_id;
         $schema_name->connect(
             @{$profile}{qw| dsn user password attributes |},
-            { on_connect_call => sub { $class->ensure_dbh_search_path_is_set(my $dbh = shift->dbh ) ; 
-
-                
-                #my $delete_old_table_query = "DROP TABLE IF EXISTS logged_in_user";
-                #my $delete = $dbh -> do($delete_old_table_query);
-                my $q = "CREATE temporary table IF NOT EXISTS logged_in_user (sp_person_id bigint)";
-                my $create_handle = $dbh -> do($q);
-                #my $count_q = "select count(*) from logged_in_user";
-                #my $count_h = $dbh -> prepare($count_q);
-                #$count_h -> execute();
-                #my ($count) = $count_h->fetchrow_array();
-                #print STDERR "count: $count \n";
-                my $insert_query = "INSERT INTO logged_in_user (sp_person_id) VALUES (?)";
-                my $insert_handle = $dbh -> prepare($insert_query);
-                $insert_handle -> execute($sp_person_id);
-               
-
-            
-            }, },
-            
-            
-            #on_connect_do => [
-            #    "CREATE temporary table IF NOT EXISTS logged_in_user (sp_person_id bigint)",
-             #   "INSERT INTO logged_in_user (sp_person_id) VALUES ($sp_person_id)",
-            #]
-            
-            
-            
-           )
+            {
+                on_connect_call => sub {
+                    $class->ensure_dbh_search_path_is_set( my $dbh = shift->dbh );
+                },
+            }
+        );
     };
+
+    # Normalise user ID
+    $sp_person_id = undef unless defined($sp_person_id) && $sp_person_id =~ /^\d+$/;
+
+    my $dbh = $schema->storage->dbh;
+
+    # Only update the logged_in_user table if the user ID has changed
+    if ( !exists $dbh->{private_sgn_user_id} || ($dbh->{private_sgn_user_id} // '') ne ($sp_person_id // '') ) {
+        $dbh->do("CREATE temporary table IF NOT EXISTS logged_in_user (sp_person_id bigint)");
+        $dbh->do("DELETE FROM logged_in_user");
+
+        if ( defined $sp_person_id ) {
+            $dbh->prepare_cached("INSERT INTO logged_in_user (sp_person_id) VALUES (?)")
+                ->execute($sp_person_id);
+        }
+        $dbh->{private_sgn_user_id} = $sp_person_id;
+    }
+
+    return $schema;
 }
 
 1;
-
-                #my $dbh = $class->dbc->dbh;
-                #$dbh->do("CREATE temporary table IF NOT EXISTS logged_in_user (sp_person_id bigint)");
-                #my $insert_query = "INSERT INTO logged_in_user (sp_person_id) VALUES (?)";
-                #my $insert_handle = $dbh->prepare($insert_query);
-                #my $sp_person_id = $class -> user -> get_object() -> get_sp_person_id;
-                #$insert_handle->execute($sp_person_id);

--- a/mason/stock/additional_info_section.mas
+++ b/mason/stock/additional_info_section.mas
@@ -74,7 +74,7 @@ $original_stock_link
 
 <div class="panel panel-default">
     <div class="panel-body panel-body-sm">
-        <b>Stock editors: </b>
+        <b>Stock owners: </b>
         <br/>
         <% $editor_link %>
     </div>

--- a/mason/stock/audit.mas
+++ b/mason/stock/audit.mas
@@ -58,7 +58,7 @@ jQuery(document).ready(function(){
             var json_object = JSON.parse(response.stock_match_after);
             var datastring;
             for (var row = 0; row < json_object.length; row++){
-                for (var column = 4; column <= 5; column++){
+                for (var column = 5; column <= 6; column++){
                     datastring = json_object[row][column];
                     if(datastring != null){
                         for(var character = 0; character < datastring.length; character++){
@@ -75,11 +75,12 @@ jQuery(document).ready(function(){
                     json_object[row][column] = datastring;
                 }
             }
-            
+
             jQuery('#stock_audit_results').DataTable({
                 data: json_object,
                 columns: [
                     { title: 'Timestamp' },
+                    { title: 'Source' },
                     { title: 'Operation' },
                     { title: 'Username' },
                     { title: 'Logged in User' },
@@ -90,18 +91,18 @@ jQuery(document).ready(function(){
                     { title: 'Is Undo'},
                 ],
                 "rowCallback" : function (row, data, index){
-                    if(data[1] == "INSERT"){
+                    if(data[2] == "INSERT"){
                         jQuery('td', row).css('background-color', 'HoneyDew');
                     }
-                    if(data[1] == "UPDATE"){
+                    if(data[2] == "UPDATE"){
                         jQuery('td',row).css('background-color', 'LightCyan');
                     }
-                    if(data[1] == "DELETE"){
+                    if(data[2] == "DELETE"){
                         jQuery('td',row).css('background-color', 'LightSalmon');
                     }
 
                 }
-                
+
             });
 
             }

--- a/mason/stock/audit.mas
+++ b/mason/stock/audit.mas
@@ -58,7 +58,7 @@ jQuery(document).ready(function(){
             var json_object = JSON.parse(response.stock_match_after);
             var datastring;
             for (var row = 0; row < json_object.length; row++){
-                for (var column = 5; column <= 6; column++){
+                for (var column = 4; column <= 5; column++){
                     datastring = json_object[row][column];
                     if(datastring != null){
                         for(var character = 0; character < datastring.length; character++){
@@ -82,7 +82,6 @@ jQuery(document).ready(function(){
                     { title: 'Timestamp' },
                     { title: 'Source' },
                     { title: 'Operation' },
-                    { title: 'Username' },
                     { title: 'Logged in User' },
                     { title: 'Before' },
                     { title: 'After' },
@@ -91,13 +90,14 @@ jQuery(document).ready(function(){
                     { title: 'Is Undo'},
                 ],
                 "rowCallback" : function (row, data, index){
-                    if(data[2] == "INSERT"){
+                    const operation = data[2];
+                    if (operation === "INSERT"){
                         jQuery('td', row).css('background-color', 'HoneyDew');
                     }
-                    if(data[2] == "UPDATE"){
+                    if (operation === "UPDATE"){
                         jQuery('td',row).css('background-color', 'LightCyan');
                     }
-                    if(data[2] == "DELETE"){
+                    if (operation === "DELETE"){
                         jQuery('td',row).css('background-color', 'LightSalmon');
                     }
 

--- a/mason/stock/audit.mas
+++ b/mason/stock/audit.mas
@@ -49,10 +49,10 @@ $stock_id
 
 
 jQuery(document).ready(function(){
-    var stock_uniquename = "<% $stock_uniquename %>";
+    var stock_id = "<% $stock_id %>";
         jQuery.ajax({
             url: '/ajax/audit/retrieve_stock_audits',
-            data: {'stock_uniquename':stock_uniquename},
+            data: {'stock_id':stock_id},
             timeout: 300000,
             success: function(response){
             var json_object = JSON.parse(response.stock_match_after);

--- a/mason/stock/index.mas
+++ b/mason/stock/index.mas
@@ -153,27 +153,6 @@ foreach my $o_id (@owner_ids){
   $owners_html .= qq|<a href="/solpeople/personal-info.pl?sp_person_id=$o_id">$first_name $last_name</a> |;
 }
 
-my $editor_link_table;
-if ($is_obsolete) {
-    $editor_link_table = "<table class='table table-bordered'><thead><tr><th>Editor</th><th>Timestamp</th><th>Modification Note</th><th>Obsolete Note</th></tr></thead><tbody>";
-    foreach my $o_id (@$owners) {
-        my $person = CXGN::People::Person->new($dbh, $o_id->[0]);
-        my $first_name = $person->get_first_name;
-        my $last_name = $person->get_last_name;
-        $editor_link_table .= qq|<tr><td><a href="/solpeople/personal-info.pl?sp_person_id=$o_id->[0]">$first_name $last_name</a></td><td>$o_id->[1]</td><td>$o_id->[2]</td><td>$o_id->[3]</td></tr>|;
-    }
-} else {
-    $editor_link_table = "<table class='table table-bordered'><thead><tr><th>Editor</th><th>Timestamp</th><th>Modification Note</th></tr></thead><tbody>";
-    foreach my $o_id (@$owners) {
-        my $person = CXGN::People::Person->new($dbh, $o_id->[0]);
-        my $first_name = $person->get_first_name;
-        my $last_name = $person->get_last_name;
-        $editor_link_table .= qq|<tr><td><a href="/solpeople/personal-info.pl?sp_person_id=$o_id->[0]">$first_name $last_name</a></td><td>$o_id->[1]</td><td>$o_id->[2]</td></tr>|;
-    }
-}
-
-$editor_link_table .= "</tbody></table>";
-$editor_link_table = "<br/>".$owners_html."<br/><br/>".$editor_link_table;
 
 #phenotypes measured directly on this stock
 my $direct_phenotypes = $stockref->{direct_phenotypes} || undef;
@@ -387,9 +366,9 @@ function jqueryStuff() {
 % }
 
 % if ($type_name ne 'vector_construct' ){
-    <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, type_name => $type_name, stockref => $stockref, buttons_html => $subtitle.$props_subtitle, info_section_title => "<h4 style='display:inline'>Additional Info</h4>", info_section_subtitle => 'View and edit additional properties such as synonyms, editors, and all types of properties.', icon_class => "glyphicon glyphicon-info-sign", info_section_id => "stock_additional_info_section", stockprops => $stockprops, edit_privs => $edit_privs, editable_stock_props => \@editable_stock_props, editor_link => $editor_link_table, source_dbs => \%source_dbs, locus_add_uri => $locus_add_uri, new_locus_link => $new_locus_link, allele_div => $allele_div, is_owner => $is_owner, derived_accession_relationship => $derived_accession_relationship, related_stock_link => $related_stock_link, original_stock_link => $original_stock_link, info_section_collapsed => 0 &>
+    <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, type_name => $type_name, stockref => $stockref, buttons_html => $subtitle.$props_subtitle, info_section_title => "<h4 style='display:inline'>Additional Info</h4>", info_section_subtitle => 'View and edit additional properties such as synonyms, editors, and all types of properties.', icon_class => "glyphicon glyphicon-info-sign", info_section_id => "stock_additional_info_section", stockprops => $stockprops, edit_privs => $edit_privs, editable_stock_props => \@editable_stock_props, editor_link => $owners_html, source_dbs => \%source_dbs, locus_add_uri => $locus_add_uri, new_locus_link => $new_locus_link, allele_div => $allele_div, is_owner => $is_owner, derived_accession_relationship => $derived_accession_relationship, related_stock_link => $related_stock_link, original_stock_link => $original_stock_link, info_section_collapsed => 0 &>
 % } else {
-    <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, type_name => $type_name, stockref => $stockref, buttons_html => $subtitle.$props_subtitle, info_section_title => "<h4 style='display:inline'>Additional Info</h4>", info_section_subtitle => 'View and edit additional properties such as synonyms, editors, and all types of properties.', icon_class => "glyphicon glyphicon-info-sign", info_section_id => "stock_additional_info_section", stockprops => $stockprops, edit_privs => $edit_privs, editable_stock_props => \@editable_vector_props, editor_link => $editor_link_table, source_dbs => \%source_dbs, locus_add_uri => $locus_add_uri, new_locus_link => $new_locus_link, allele_div => $allele_div, is_owner => $is_owner, info_section_collapsed => 0 &>
+    <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, type_name => $type_name, stockref => $stockref, buttons_html => $subtitle.$props_subtitle, info_section_title => "<h4 style='display:inline'>Additional Info</h4>", info_section_subtitle => 'View and edit additional properties such as synonyms, editors, and all types of properties.', icon_class => "glyphicon glyphicon-info-sign", info_section_id => "stock_additional_info_section", stockprops => $stockprops, edit_privs => $edit_privs, editable_stock_props => \@editable_vector_props, editor_link => $owners_html, source_dbs => \%source_dbs, locus_add_uri => $locus_add_uri, new_locus_link => $new_locus_link, allele_div => $allele_div, is_owner => $is_owner, info_section_collapsed => 0 &>
 %#    <& /page/detail_page_2_col_section.mas, stock_id => $stock_id, type_name => $type_name, stockref=> $stockref, info_section_title => "<h4 style='display:inline' >Vector Viewer</h4>", info_section_subtitle => "", info_section_id => "vector_view", edit_privs => $edit_privs,  is_owner => $is_owner, info_section_collapsed => 0 &>
     <& /page/detail_page_2_col_section.mas, vector_id => $stock_id, info_section_title => "<h4 style='display:inline'>Transgenic Line Details</h4>", info_section_subtitle => 'View number of transgene insertions and qPCR data.',buttons_html => '<button class="btn btn-primary btn-sm" id="upload_qPCR_data_link_vector_page" name="upload_qPCR_data_link" style="margin:3px">Upload qPCR Data</button>', icon_class => "glyphicon glyphicon-list-alt", info_section_id => "transgenic_line_details_section", vector_name => $uniquename, type_name => $type_name, vector_related_genes => $vector_related_genes, vector_analyzed_tissue_types => $vector_analyzed_tissue_types &>
     <& /page/detail_page_2_col_section.mas, info_section_title => "<h4 style='display:inline'>Obsoleted Transgenic Lines</h4>", info_section_subtitle => 'View obsoleted accessions (transgenic lines) and metadata.', icon_class => "glyphicon glyphicon-remove", info_section_id => "obsoleted_accessions_section", vector_id => $stock_id &>

--- a/t/selenium2/stock/stock_audit.t
+++ b/t/selenium2/stock/stock_audit.t
@@ -1,0 +1,149 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+
+use lib 't/lib';
+use SGN::Test::WWW::WebDriver;
+use SGN::Test::Fixture;
+
+my $t = SGN::Test::WWW::WebDriver->new();
+my $f = SGN::Test::Fixture->new();
+
+sub open_additional_info_section {
+    my $switch = $t->find_element('stock_additional_info_section_onswitch', 'id');
+    if ($switch && $switch->is_displayed()) {
+        $switch->click();
+        $t->wait_for_network_idle();
+    }
+}
+
+# Generic runner to execute arbitrary UI changes on a stock page and verify relevant logs
+sub run_change_audit_test {
+    my ($stock_id, $username, $changes) = @_;
+
+    foreach my $change (@$changes) {
+        $t->get_ok("stock/$stock_id/view");
+        $t->wait_for_network_idle();
+
+        if ($change->{type} eq 'stock_details') {
+            $t->click_ok('//div[@id="stock_details_buttons"]/a[contains(text(), "Edit")]', 'xpath', 'Click stock edit button');
+
+            while (my ($field_name, $value) = each %{$change->{fields}}) {
+                $t->clear_ok($field_name, 'name', "Clear input: $field_name");
+                $t->send_keys_ok($field_name, 'name', $value, "Update $field_name");
+            }
+
+            $t->click_ok('stockForm_submit_button', 'id', 'Click save details button');
+            $t->wait_for_network_idle();
+
+        } elsif ($change->{type} eq 'stock_prop' && $change->{action} eq 'INSERT') {
+            open_additional_info_section();
+            $t->wait_for_network_idle();
+
+            $t->click_ok("stock_add_synonym", "id", "Open add synonym dialog");
+            $t->click_ok("synonyms_select", "id", "Focus synonym selector");
+            $t->click_ok('//select[@id="synonyms_select"]/option[@title="stock_synonym"]', 'xpath', "Select stock_synonym");
+
+            my $prop_val = $change->{fields}->{value};
+            $t->send_keys_ok("synonyms_prop", "id", $prop_val, "Fill synonym value");
+            $t->click_ok("synonyms_addProp_submit", "id", "Submit property addition");
+            $t->accept_alert();
+            $t->wait_for_network_idle();
+
+        } elsif ($change->{type} eq 'stock_prop' && $change->{action} eq 'DELETE') {
+            open_additional_info_section();
+            $t->wait_for_network_idle();
+
+            my $prop_val = $change->{fields}->{value};
+            $prop_val =~ s/^\s+|\s+$//g; # Strip any trailing/leading white space or newlines
+
+            my $xpath = sprintf('//table[@id="synonyms_content"]//span[contains(@class, "stockprop-pill") and contains(., "%s")]/a[contains(@class, "stockprop-delete")]', $prop_val);
+            $t->click_ok($xpath, 'xpath', 'Click delete stockprop button');
+            $t->accept_alert();
+            $t->accept_alert();
+            $t->wait_for_network_idle();
+        }
+    }
+
+    # Reload page and perform batch validation on the entire audit table after all edits
+    $t->get_ok("stock/$stock_id/view");
+    $t->wait_for_network_idle();
+
+    $t->click_ok('audit_table_section_onswitch', 'id', 'Open audit table panel');
+    $t->wait_for_network_idle();
+
+    my $audit_text = $t->get_text('stock_audit_results', 'id');
+
+    foreach my $change (@$changes) {
+        my $op = $change->{action};
+        my $pattern = $change->{expected_pattern};
+
+        ok($audit_text =~ /$op/, "Batch verification: Audit logs recorded $op operation");
+        ok($audit_text =~ /$username/, "Batch verification: Audit logs associated with user: $username");
+        ok($audit_text =~ /$pattern/, "Batch verification: Audit details contain: $pattern");
+    }
+}
+
+$t->while_logged_in_as("submitter", sub {
+    run_change_audit_test(
+        38879,
+        'johndoe',
+        [
+            {
+                type             => 'stock_details',
+                action           => 'UPDATE',
+                fields           => { description => 'Generic automated update audit testing description.' },
+                expected_pattern => 'Generic automated update audit testing description.',
+            },
+            {
+                type             => 'stock_prop',
+                action           => 'INSERT',
+                fields           => { value => 'generic_audit_prop_val' },
+                expected_pattern => 'generic_audit_prop_val',
+            }
+        ]
+    );
+
+    run_change_audit_test(
+        38879,
+        'johndoe',
+        [
+            {
+                type             => 'stock_details',
+                action           => 'UPDATE',
+                fields           => { description => 'Second automated update note.' },
+                expected_pattern => 'Second automated update note.',
+            },
+            {
+                type             => 'stock_details',
+                action           => 'UPDATE',
+                fields           => { description => 'Third final automated details patch.' },
+                expected_pattern => 'Third final automated details patch.',
+            }
+        ]
+    );
+
+    run_change_audit_test(
+        38879,
+        'johndoe',
+        [
+            {
+                type             => 'stock_prop',
+                action           => 'INSERT',
+                fields           => { value => 'temporary_audit_synonym_val' },
+                expected_pattern => 'temporary_audit_synonym_val',
+            },
+            {
+                type             => 'stock_prop',
+                action           => 'DELETE',
+                fields           => { value => 'temporary_audit_synonym_val' },
+                expected_pattern => 'temporary_audit_synonym_val',
+            }
+        ]
+    );
+});
+
+$t->driver->quit();
+$f->clean_up_db();
+done_testing();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

The **Stock editors** section has been rename **Stock owners** and displays the stock owners but not the modification table:

<img width="1278" height="380" alt="image" src="https://github.com/user-attachments/assets/a44ebc7f-9222-4507-b511-29317a17926b" />

The **Audit Log** section now:
1. shows changes to stockprops
2. always includes the logged in user
   - this column now displays the username instead of the user ID
3. includes a new **Source** column indicating whether the entry is a stock or stockprop change

<img width="1488" height="680" alt="image" src="https://github.com/user-attachments/assets/03bdb762-5f78-4872-877b-c440be077881" />


Closes #186 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
