### PR TITLE
fix(bin): fix rename stock synonyms for #140

### DIFF
--- a/bin/rename_stocks.pl
+++ b/bin/rename_stocks.pl
@@ -132,17 +132,27 @@ my $coderef = sub {
 	}
 	
         my $new_stock = $old_stock->update({ name => $new_uniquename, uniquename => $new_uniquename});
-	if (! $opt_n) {
-	    print STDERR "Storing old name ($db_uniquename) as synonym or stock with id ".$new_stock->stock_id()." and type_id $synonym_id...\n";
-	    my $synonym = { value => $db_uniquename,
-			    type_id => $synonym_id,
-			    stock_id => $new_stock->stock_id(),
-	    };
+        if (! $opt_n) {
+            # Get next rank for a new synonym
+            my $synonym_rs = $schema->resultset('Stock::Stockprop')->search({type_id => $synonym_id, stock_id => $new_stock->stock_id()});
+            my $rank = 0;
+            while (my $r = $synonym_rs->next()){
+                if ($r->rank  >= $rank){
+                    $rank = $r->rank + 1;
+                }
+            }
 
-	    print STDERR "find_or_create...\n";
-	    $schema->resultset('Stock::Stockprop')->find_or_create($synonym);
-	    print STDERR "Done.\n";
-	}
+            print STDERR "Storing old name ($db_uniquename) as synonym or stock with id ".$new_stock->stock_id()." and type_id $synonym_id and rank $rank...\n";
+            my $synonym = { value => $db_uniquename,
+                    type_id => $synonym_id,
+                    stock_id => $new_stock->stock_id(),
+                    rank => $rank,
+            };
+
+            print STDERR "find_or_create...\n";
+            $schema->resultset('Stock::Stockprop')->find_or_create($synonym);
+            print STDERR "Done.\n";
+        }
     }
 };
 

--- a/db/00205.1/IndexStockPropSynonym.pm
+++ b/db/00205.1/IndexStockPropSynonym.pm
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+
+=head1 NAME
+
+IndexStockPropSynonym.pm
+
+=head1 SYNOPSIS
+
+mx-run IndexStockPropSynonym [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+This patch:
+ - adds an index to stockprop to ensure synonyms are unique.
+
+=head1 AUTHOR
+
+Katherine Eaton
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2026 University of Alberta
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+package IndexStockPropSynonym;
+
+use Moose;
+use Bio::Chado::Schema;
+extends 'CXGN::Metadata::Dbpatch';
+
+has '+description' => ( default => <<'' );
+This patch adds an index to stockprop to ensure synonyms are unique.
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    $self->dbh->do(<<EOSQL);
+create unique index stockprop_idx3 on stockprop (value) where (type_id = 76487);
+
+EOSQL
+
+    print "You're done!\n";
+}
+
+####
+1; #
+####


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixes a bug where stocks that already have a synonym can't be renamed using the bulk stock tool.

- Resolves #140

<!-- If there are relevant issues, link them here: -->

We don't have an automated testing framework for the utility scripts in `bin/`. But these are some manual testing steps, using the DEVELOPMENT server:

```bash
# 1. Enter the container
docker compose -f compose.development.yml exec breedbase bash

# 2. Download utility for creating excel files, db credentials are 'postgres' and 'postgres'
wget https://github.com/shenwei356/csvtk/releases/download/v0.37.0/csvtk_linux_amd64.tar.gz
tar -xvf csvtk_linux_amd64.tar.gz
./csvtk --help

# 3. Create excel file of stocks to rename
echo "test_accession,test_accession_rename1" | ./csvtk csv2xlsx -H -o /downloads/rename1.xlsx
perl bin/rename_stocks.pl -H $PGHOST -D $PGDATABASE -s accession -i /downloads/rename1.xlsx

# 4. Check that the old name (test_accession) is now a synonym in stockprop:
psql -c 'select * from stockprop where stock_id = 41784';
 stockprop_id | stock_id | type_id |               value               | rank | value_jsonb
--------------+----------+---------+-----------------------------------+------+-------------
        45149 |    41784 |   77140 | http://localhost/stock/41784/view |    0 |
        45150 |    41784 |   76487 | test_accession                    |    0 |

# 5. Rename the stock a second time. This is where you would get an error without this PR's fix.
echo "test_accession_rename1,test_accession_rename2" | ./csvtk csv2xlsx -H -o /downloads/rename2.xlsx
perl bin/rename_stocks.pl -H $PGHOST -D $PGDATABASE -s accession -i /downloads/rename2.xlsx

# 6. Check that the old name (test_accession_rename1) is now a synonym in stockprop:
psql -c 'select * from stockprop where stock_id = 41784';
 stockprop_id | stock_id | type_id |               value               | rank | value_jsonb
--------------+----------+---------+-----------------------------------+------+-------------
        45149 |    41784 |   77140 | http://localhost/stock/41784/view |    0 |
        45150 |    41784 |   76487 | test_accession                    |    0 |
        45152 |    41784 |   76487 | test_accession_rename1            |    1 |
```

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
