### PR TITLE
fix(marker): allow marker metadata to link to composed trait

### DIFF
--- a/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
@@ -201,6 +201,12 @@ sub _validate_with_plugin {
         # Get children (recursively) of root cvterm
         my $ontology = [];
         $ontology = $onto->get_children($root_cvterm_id) if $root_cvterm_id;
+        my $composed_ontology = [];
+        my $composed_trait_ont_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'Composed traits', 'composed_trait')->cvterm_id();
+        $composed_ontology = $onto->get_children($composed_trait_ont_cvterm_id);
+
+        # Build hash of names => cvterm ids
+        my $ontology_terms = _parse_ontology_term([$ontology, $composed_ontology]);
 
         # Build hash of names => cvertm ids
         my $ontology_terms = _parse_ontology_term($ontology);

--- a/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
+++ b/lib/CXGN/Genotype/ParseUpload/Plugin/MarkerMetadata.pm
@@ -201,15 +201,11 @@ sub _validate_with_plugin {
         # Get children (recursively) of root cvterm
         my $ontology = [];
         $ontology = $onto->get_children($root_cvterm_id) if $root_cvterm_id;
-        my $composed_ontology = [];
         my $composed_trait_ont_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'Composed traits', 'composed_trait')->cvterm_id();
-        $composed_ontology = $onto->get_children($composed_trait_ont_cvterm_id);
+        my $composed_ontology = $onto->get_children($composed_trait_ont_cvterm_id);
 
         # Build hash of names => cvterm ids
         my $ontology_terms = _parse_ontology_term([$ontology, $composed_ontology]);
-
-        # Build hash of names => cvertm ids
-        my $ontology_terms = _parse_ontology_term($ontology);
 
         # Ensure the trait categories are valid ontology terms
         my @missing_categories;

--- a/t/data/genotype_data/marker_metadata.csv
+++ b/t/data/genotype_data/marker_metadata.csv
@@ -2,3 +2,4 @@ Marker,Alias,Description,Category,Allele,Allele,Allele,Reference
 S1_21597,,Description of Marker 1,Stem height,1_P,1_A,1_H,
 S1_26576,ML_2,Description of Marker 2,Fresh root yield,2_P,2_A,,
 S2_26659,,Description of Marker 3,,3_P,3_A,3_H,
+S2_26674,,Marker 4 links to a composed trait,cass sink leaf|ADP|ug/g|week 16,A,,,

--- a/t/unit_mech/AJAX/MarkerMetadata.t
+++ b/t/unit_mech/AJAX/MarkerMetadata.t
@@ -86,7 +86,12 @@ is($upload_resp->{success}, 1, 'Upload marker metadata - success');
 # Get Marker Metadata (all)
 $mech->get_ok("http://localhost:3010/ajax/genotyping_protocol/get_marker_metadata/$protocol_id", 'Get marker metadata - all');
 $response = decode_json $mech->content;;
-my $expected = {'ML_2' => {'locus_id' => 4,'alleles' => [{'allele_name' => '2_P','allele_id' => 2},{'allele_name' => '2_A','allele_id' => 3}],'references' => [{'url' => '/cvterm/70691/view','db_name' => 'CO_334','cvterm_id' => 70691,'cvterm_name' => 'fresh root yield','dbxref_accession' => '0000013'}],'marker_name' => 'S1_26576','nd_protocol_id' => 3,'locus_name' => 'ML_2','locus_description' => 'Description of Marker 2'},'S1_21597' => {'locus_name' => 'S1_21597','locus_description' => 'Description of Marker 1','nd_protocol_id' => 3,'marker_name' => 'S1_21597','locus_id' => 6,'alleles' => [{'allele_name' => '1_P','allele_id' => 7},{'allele_id' => 8,'allele_name' => '1_A'},{'allele_id' => 9,'allele_name' => '1_H'}],'references' => [{'dbxref_accession' => '0000478','url' => '/cvterm/76801/view','db_name' => 'CO_334','cvterm_id' => 76801,'cvterm_name' => 'Stem height'}]},'S2_26659' => {'locus_description' => 'Description of Marker 3','locus_name' => 'S2_26659','nd_protocol_id' => 3,'marker_name' => 'S2_26659','references' => [],'alleles' => [{'allele_name' => '3_P','allele_id' => 4},{'allele_name' => '3_A','allele_id' => 5},{'allele_name' => '3_H','allele_id' => 6}],'locus_id' => 5}};
+my $expected = {
+    'ML_2' => {'locus_id' => 4, 'alleles' => [{'allele_name' => '2_P','allele_id' => 2},{'allele_name' => '2_A','allele_id' => 3}], 'references' => [{'url' => '/cvterm/70691/view','db_name' => 'CO_334','cvterm_id' => 70691,'cvterm_name' => 'fresh root yield','dbxref_accession' => '0000013'}], 'marker_name' => 'S1_26576','nd_protocol_id' => 3,'locus_name' => 'ML_2','locus_description' => 'Description of Marker 2'},
+    'S1_21597' => {'locus_name' => 'S1_21597','locus_description' => 'Description of Marker 1','nd_protocol_id' => 3,'marker_name' => 'S1_21597','locus_id' => 6,'alleles' => [{'allele_name' => '1_P','allele_id' => 7},{'allele_id' => 8,'allele_name' => '1_A'},{'allele_id' => 9,'allele_name' => '1_H'}],'references' => [{'dbxref_accession' => '0000478','url' => '/cvterm/76801/view','db_name' => 'CO_334','cvterm_id' => 76801,'cvterm_name' => 'Stem height'}]},
+    'S2_26659' => {'locus_description' => 'Description of Marker 3','locus_name' => 'S2_26659','nd_protocol_id' => 3,'marker_name' => 'S2_26659','references' => [],'alleles' => [{'allele_name' => '3_P','allele_id' => 4},{'allele_name' => '3_A','allele_id' => 5},{'allele_name' => '3_H','allele_id' => 6}],'locus_id' => 5},
+    "S2_26674" => {"locus_id" => 5, "locus_description" => "Marker 4 links to a composed trait", "locus_name" => "S2_26674", "references" => [{ "dbxref_accession" => "0000010", "db_name" => "COMP", "url" => "/cvterm/77556/view", "cvterm_name" => "cass sink leaf|ADP|ug/g|week 16", "cvterm_id" => 77556 }], "marker_name" => "S2_26674", "nd_protocol_id" => 3, "alleles" => [{"allele_name" => "A", "allele_id" => 5}]},
+};
 check_metadata_response($expected, $response, "all");
 
 
@@ -113,6 +118,11 @@ $response = decode_json $mech->content;
 $expected = {'S1_21597' => {'alleles' => [{'allele_id' => 10,'allele_name' => '1_P'},{'allele_id' => 11,'allele_name' => '1_A'},{'allele_id' => 12,'allele_name' => '1_UNK'}],'locus_name' => 'S1_21597','nd_protocol_id' => 3,'locus_description' => 'Updated description of Marker 1','references' => [{'cvterm_id' => 76801,'db_name' => 'CO_334','cvterm_name' => 'Stem height','url' => '/cvterm/76801/view','dbxref_accession' => '0000478'}],'locus_id' => 7,'marker_name' => 'S1_21597'}};
 check_metadata_response($expected, $response, "S1_21597 - updated");
 
+# Check Marker Metadata that links to composed trait (S2_26674)
+$mech->get_ok("http://localhost:3010/ajax/genotyping_protocol/get_marker_metadata/$protocol_id?marker_name=S2_26674", 'Get marker metadata - S2_26674');
+$response = decode_json $mech->content;
+$expected = {'S2_26674' => {'references' => [{'db_name' => 'COMP','cvterm_name' => 'cass sink leaf|ADP|ug/g|week 16','url' => '/cvterm/77556/view','cvterm_id' => 77556,'dbxref_accession' => '0000010'}],'locus_name' => 'S2_26674','marker_name' => 'S2_26674','locus_id' => 7,'alleles' => [{'allele_name' => 'A','allele_id' => 10}],'locus_description' => 'Marker 4 links to a composed trait','nd_protocol_id' => 3}};
+check_metadata_response($expected, $response, "S2_26674 - composed trait");
 
 # Delete marker metadata
 $response = $ua->delete("http://localhost:3010/ajax/genotyping_protocol/delete_marker_metadata/$protocol_id", Cookie => "sgn_session_id=$sgn_session_id");


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Allows genotyping markers to have metadata that links them to traits in the composed ontology. I would consider this a 'fix', as this seems like functionality that already should have been working.

Previously, markers could only be linked to a singular trait ontology (ex. TI_TRAIT). Now it may link to both our main trait ontology, and the composed one.

<!-- If there are relevant issues, link them here: -->
- Resolves #153

<img width="780" alt="image" src="https://github.com/user-attachments/assets/f92b29aa-e167-4c0b-b74e-69ff04a4b051" />


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
