### PR TITLE
feat(trial): order plots table in experimental design

### DIFF
--- a/mason/breeders_toolbox/trial/trial_plots.mas
+++ b/mason/breeders_toolbox/trial/trial_plots.mas
@@ -55,6 +55,7 @@ jQuery(document).ready(function () {
                     paging: false,
                     searching: true,
                     ordering: true,
+                    order: [[2, 'asc']],
                     info: true,
                     scrollY: '250px',
                     scrollX : true,


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Sets a default sort order for the plots table in a trials experimental design, otherwise it is random. Using the second column (plot_number) is a nice default, because we often use that to represent our planting order.

<!-- If there are relevant issues, link them here: -->
- Resolves #86

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
