### PR TITLE
fix(marker): remove organism common name from locus title

### DIFF
--- a/mason/locus/index.mas
+++ b/mason/locus/index.mas
@@ -220,7 +220,7 @@ my $ontology_subtitle = $curator || $submitter || $sequencer  ?
 </script>
 
 
-<& /page/page_title.mas, title=> "$common_name locus ".$locus->get_locus_name &>
+<& /page/page_title.mas, title=> "Locus ".$locus->get_locus_name &>
 
 
 <&| /page/info_section.mas, title=>"Locus details" , subtitle => "$locus_xml | $editor_note | $guide_html" &>


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixes the title of the  marker metadata page, which would always have the prefix "Cassava". This might have been a holdover hard-coding, in which breedbase instances were meant to serve a singular species (ex. cassava).

In a marker metadata page, the title of the page would have the format

<!-- If there are relevant issues, link them here: -->
- Resolves #154

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
