### PR TITLE
fix(marker): fix table overflow in genotyping protocol page

### DIFF
--- a/mason/breeders_toolbox/genotyping_protocol/details.mas
+++ b/mason/breeders_toolbox/genotyping_protocol/details.mas
@@ -13,7 +13,7 @@ $assay_type
 </%args>
 
 <div class="row">
-    <div class="col-sm-12" style="overflow: auto; min-width: 0px">
+    <div class="col-sm-12 tw:min-w-0 tw:overflow-auto">
 
         <table class="table table-hover table-bordered" >
 

--- a/mason/breeders_toolbox/genotyping_protocol/details.mas
+++ b/mason/breeders_toolbox/genotyping_protocol/details.mas
@@ -13,7 +13,7 @@ $assay_type
 </%args>
 
 <div class="row">
-    <div class="col-sm-12">
+    <div class="col-sm-12" style="overflow: auto; min-width: 0px">
 
         <table class="table table-hover table-bordered" >
 

--- a/mason/breeders_toolbox/genotyping_protocol/marker_metadata.mas
+++ b/mason/breeders_toolbox/genotyping_protocol/marker_metadata.mas
@@ -128,7 +128,8 @@
                         html += `<button class="btn btn-sm btn-danger" style="margin: 5px" onclick="deleteMetadata(${row.locus_id})" <% $curator ? '' : 'disabled' %>><span class="glyphicon glyphicon-trash"></span></button>`;
                         return html;
                     }}
-                ]
+                ],
+                scrollX: true,
             });
         }
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Fixes assorted table horizontal overflows in Genotyping Protocol page.

<!-- If there are relevant issues, link them here: -->
- Resolves #202 

The underlying problem was that no scroll behavior was set, the class `col-sm-12` has a minimum width set in `treeimprovementbase.css` that needed to be overriden.

<details>
<summary><b>Expand for manual testing notes</b></summary>
For manual testing, I used the Marker Metadata tests, and put a sleep right before the data is deleted:

```text
check_metadata_response($expected, $response, "S1_21597 - updated");

sleep(10000);

# Delete marker metadata
```

Then created the test data with the following command, and explored the ui at <http://localhost:3010>:
```bash
./run_test t/unit_mech/AJAX/MarkerMetadata.t
```
</details>

| Before | After |
| ------- | ------ |
| <img width="780" alt="image" src="https://github.com/user-attachments/assets/12acb63e-3bbe-440d-a192-9c963433b52f" /> | <img width="681" height="769" alt="image" src="https://github.com/user-attachments/assets/a08c98ab-f30e-420b-8892-a20691b6dd76" /> |
| |  <img width="680" height="711" alt="image" src="https://github.com/user-attachments/assets/df8d3d25-7540-4d79-b404-c32e3b2518c1" /> |


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
