### PR TITLE
fix(cluster): scope clustering option selectors to clicked row

### DIFF
--- a/js/source/legacy/solGS/cluster.js
+++ b/js/source/legacy/solGS/cluster.js
@@ -720,16 +720,18 @@ solGS.cluster = {
     this.clusterResult(clusterArgs);
   },
 
-  clusteringOptions: function (clusterPopId) {
+  clusteringOptions: function (clusterPopId, context) {
     var clusterTypeId = this.clusterTypeSelectId(clusterPopId);
     var kNumId = this.clusterKnumSelectId(clusterPopId);
     var dataTypeId = this.clusterDataTypeSelectId(clusterPopId);
     var selectionPropId = this.clusterSelPropSelectId(clusterPopId);
 
-    var dataType = jQuery("#" + dataTypeId).val() || "genotype";
-    var clusterType = jQuery("#" + clusterTypeId).val() || "k-means";
-    var kNumber = jQuery("#" + kNumId).val() || 'default';
-    var selectionProp = jQuery("#" + selectionPropId).val();
+    var $ctx = context ? jQuery(context) : jQuery(document);
+
+    var dataType = $ctx.find("#" + dataTypeId).val() || "genotype";
+    var clusterType = $ctx.find("#" + clusterTypeId).val() || "k-means";
+    var kNumber = $ctx.find("#" + kNumId).val() || 'default';
+    var selectionProp = $ctx.find("#" + selectionPropId).val();
 
     if (typeof kNumber === "string") {
       kNumber = kNumber.replace(/\s+/g, "");
@@ -1227,7 +1229,8 @@ jQuery(document).ready(function () {
 
       var clusterOptsId = "cluster_options";
       var clusterPopId = solGS.cluster.getClusterPopId(selectedId, dataStr);
-      var clusterOpts = solGS.cluster.clusteringOptions(clusterPopId);
+      var row = jQuery(e.target).closest("tr");
+      var clusterOpts = solGS.cluster.clusteringOptions(clusterPopId, row);
 
       var clusterArgs = {
         selected_id: selectedId,


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixes `clusteringOptions` to accept a row context to avoid incorrect value resolution when duplicate DOM elements exist (e.g., when datasets are listed both publicly and privately).

This fixes the UI sending the "genotyping" data type to the backend when "phenotyping" is selected.

Closes #56 
<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
