### PR TITLE
fix: preserve empty range filter lines

### DIFF
--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -471,9 +471,7 @@ jQuery(document).ready(function () {
                 $group.find('.range-row-error').hide();
             }
             
-            if (minVal !== '' || maxVal !== '') {
-                ranges_values.push(minVal + ',' + maxVal);
-            }
+            ranges_values.push(minVal + ',' + maxVal);
         });
 
         editable_stockprops_search[prop]["value"] = ranges_values.join(';');
@@ -582,8 +580,12 @@ jQuery(document).ready(function () {
             current_val = ',';
         }
         const ranges = current_val.split(';');
+        console.log("prev ranges: ", ranges);
         ranges.splice(index + 1, 0, ',');
+        console.log("new ranges: ", ranges);
         editable_stockprops_search[prop]["value"] = ranges.join(';');
+        console.log("prev: ", current_val);
+        console.log("new: ", editable_stockprops_search[prop]["value"]);
         _draw_editable_stockprops_search_fields();
     });
 

--- a/mason/search/stocks.mas
+++ b/mason/search/stocks.mas
@@ -580,12 +580,8 @@ jQuery(document).ready(function () {
             current_val = ',';
         }
         const ranges = current_val.split(';');
-        console.log("prev ranges: ", ranges);
         ranges.splice(index + 1, 0, ',');
-        console.log("new ranges: ", ranges);
         editable_stockprops_search[prop]["value"] = ranges.join(';');
-        console.log("prev: ", current_val);
-        console.log("new: ", editable_stockprops_search[prop]["value"]);
         _draw_editable_stockprops_search_fields();
     });
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
