### PR TITLE
fix(job): Job status is failed even when it runs successfully

### DIFF
--- a/lib/CXGN/Job.pm
+++ b/lib/CXGN/Job.pm
@@ -295,7 +295,7 @@ sub BUILD {
         $self->additional_args($job_args->{additional_args});
         $self->cxgn_tools_run_config($job_args->{cxgn_tools_run_config});
         $self->cmd($job_args->{cmd});
-        my $logfile = $job_args->{finish_logfile};
+        my $logfile = $args->{finish_logfile};
         $self->finish_logfile($logfile);
     }
 }
@@ -555,7 +555,7 @@ sub store {
             $row->args(JSON::Any->encode({
                 cxgn_tools_run_config => $self->cxgn_tools_run_config(),
                 name => $self->name(),
-                # finish_logfile => $self->finish_logfile(),
+                finish_logfile => $self->finish_logfile(),
                 cmd => $self->cmd(),
                 results_page => $self->results_page(),
                 submit_page => $self->submit_page(),

--- a/mason/dataset/index.mas
+++ b/mason/dataset/index.mas
@@ -65,24 +65,14 @@ $dataset_contents => ''
     }
 
     .wizard-datasets {
-        border: 2px solid black;
+        border: 1px solid black;
         overflow: auto;
         height: 80vh;
     }
-    #dataset_results>tbody>tr>td:nth-child(1) {
-        border-left-width: 0px;
+    #dataset_results {
+        border-collapse: collapse;
+        border-style: hidden;
     }
-    #dataset_results>tbody>tr>td:nth-child(2) {
-        border-right-width: 0px;
-    }
-    #dataset_results>tbody>tr:first-child>td {
-        border-top-width: 0px;
-    }
-    #dataset_results>tbody>tr:last-child>td {
-        border-bottom-width: 0px;
-    }
-
-
 </style>
 
 <head>

--- a/mason/dataset/index.mas
+++ b/mason/dataset/index.mas
@@ -64,6 +64,25 @@ $dataset_contents => ''
         padding: 0px;
     }
 
+    .wizard-datasets {
+        border: 2px solid black;
+        overflow: auto;
+        height: 80vh;
+    }
+    #dataset_results>tbody>tr>td:nth-child(1) {
+        border-left-width: 0px;
+    }
+    #dataset_results>tbody>tr>td:nth-child(2) {
+        border-right-width: 0px;
+    }
+    #dataset_results>tbody>tr:first-child>td {
+        border-top-width: 0px;
+    }
+    #dataset_results>tbody>tr:last-child>td {
+        border-bottom-width: 0px;
+    }
+
+
 </style>
 
 <head>
@@ -108,7 +127,7 @@ Warning symbols indicate compatibility, but with low sample
 sizes. Hover for details."></span>
                     <br>
                     <td>
-                        <div id="predicted-tool-compatibility" style="width:85%;overflow-x:auto;overflow-y:auto">
+                        <div id="predicted-tool-compatibility">
                         </div>  
                         <div><br><button type="button" class="btn btn-sm btn-success" id="tool-compatibility-calc-button" >Check Tool Compatibility</button></div>
                     <tr><td>Analyses using this dataset<td id="dataset_analysis_usage"></td></td>
@@ -194,27 +213,17 @@ sizes. Hover for details."></span>
             <div id="trait_graph"></div>
         </div>
         <div class="col-md-12">
-            <div class="input-group-btn col-md-11 col-md-offset-1">
-                <span>
-                    <button class="btn btn-sm btn-success btn-dataset" id="store_outliers">Add selection to outliers</button>
-                </span>                
-                <span>
-                        <button class="btn btn-sm btn-danger btn-dataset" id="reset_trait">Reset outliers for current trait</button>
-                </span>
-                <span>
-                        <button class="btn btn-sm btn-danger btn-dataset" id="reset_outliers">Reset all outliers</button>
-                </span>
-                <span>
-                    <button class="btn btn-sm btn-primary btn-dataset" id="outliers_phenotype_download">Download Phenotype Table without outliers</button>
-                </span>
-                <span>
-                    <button class="btn btn-sm btn-primary btn-dataset" id="rosner_test">Make Rosner outlier test</button>
-                    <img id="loading-spinner" src="/img/wheel.gif" alt="loading" style="visibility: hidden;">
-                </span>
+            <div class="tw:flex tw:gap-2.5 tw:flex-wrap tw:mb-3.75 tw:mt-2.5">
+                <button class="btn btn-sm btn-success btn-dataset" id="store_outliers">Add selection to outliers</button>
+                <button class="btn btn-sm btn-danger btn-dataset" id="reset_trait">Reset outliers for current trait</button>
+                <button class="btn btn-sm btn-danger btn-dataset" id="reset_outliers">Reset all outliers</button>
+                <button class="btn btn-sm btn-primary btn-dataset" id="outliers_phenotype_download">Download Phenotype Table without outliers</button>
+                <button class="btn btn-sm btn-primary btn-dataset" id="rosner_test">Make Rosner outlier test</button>
+                <img id="loading-spinner" src="/img/wheel.gif" alt="loading" style="visibility: hidden;">
             </div>
         </div>
     </div>
-    <div class="row well" style="margin: 5px 10px;">
+    <div class="row well">
       Rosner's test is calculated by the R function rosnerTest{EnvStats} from package EnvStats.<br>
         <a href="https://cran.r-project.org/web/packages/EnvStats/index.html">https://cran.r-project.org/web/packages/EnvStats/index.html</a>
     </div>
@@ -246,8 +255,10 @@ sizes. Hover for details."></span>
         function populate_tool_compatibility(json) {
 
             var data_summary = {};
+            // Display tools in table sorted alphabetically by name
+            var ordered_keys = Object.keys(json).toSorted();
 
-            for (key in json) {
+            for (const key of ordered_keys) {
                if (key == "Data Summary"){
                    var newkey = '<b>' + key + '</b>';
                    data_summary[newkey] = json[key];
@@ -278,7 +289,7 @@ sizes. Hover for details."></span>
             
             function recursive_table_gen(obj) {
                 if (Object.prototype.toString.call(obj) == "[object Array]") {
-                    let table = '<table border="1"><tr><td><p>' + obj.join("</p><p>") + '</p></table>';
+                    let table = '<table class="well"><tr><td><p>' + obj.join("</p><p>") + '</p></table>';
                     return table;
                 }
                 var keys = [];
@@ -288,7 +299,7 @@ sizes. Hover for details."></span>
                 if (keys.length == 0) {
                     return "";
                 }
-                let table = '<table border="1"><tr><td>' + keys.join("<td>") + '</table>';
+                let table = '<table border="1" style="border-color: #ddd"><tr><td>' + keys.join("<td>") + '</table>';
                 return table;
             }
 
@@ -332,7 +343,7 @@ sizes. Hover for details."></span>
                          jQuery('#predicted-tool-compatibility').text(response.tool_compatibility);
                     } else {
                         //console.log(JSON.parse(response.tool_compatibility));
-                        jQuery('#predicted-tool-compatibility').css('height', '400px');
+                        // jQuery('#predicted-tool-compatibility').css('height', '400px');
                         jQuery('#predicted-tool-compatibility').html(populate_tool_compatibility(JSON.parse(response.tool_compatibility)));
                     }
                 }

--- a/mason/dataset/index.mas
+++ b/mason/dataset/index.mas
@@ -246,7 +246,7 @@ sizes. Hover for details."></span>
 
             var data_summary = {};
             // Display tools in table sorted alphabetically by name
-            var ordered_keys = Object.keys(json).toSorted();
+            var ordered_keys = Array.from(Object.keys(json)).sort();
 
             for (const key of ordered_keys) {
                if (key == "Data Summary"){

--- a/mason/dataset/index.mas
+++ b/mason/dataset/index.mas
@@ -73,6 +73,9 @@ $dataset_contents => ''
         border-collapse: collapse;
         border-style: hidden;
     }
+    #dataset_results>tbody>tr>td {
+        border: 1px solid black;
+    }
 </style>
 
 <head>
@@ -89,7 +92,7 @@ $dataset_contents => ''
 <body>
     <div id="wizard" class="row">
         <div class="wizard-datasets">
-            <table id="dataset_results"; border="1">
+            <table id="dataset_results">
                     <tr><td>Name<td><% $dataset_name %>
 %                   if ($c->user()) {
                     <tr><td>Description
@@ -289,7 +292,7 @@ sizes. Hover for details."></span>
                 if (keys.length == 0) {
                     return "";
                 }
-                let table = '<table border="1" style="border-color: #ddd"><tr><td>' + keys.join("<td>") + '</table>';
+                let table = '<table class="table-bordered"><tr><td>' + keys.join("<td>") + '</table>';
                 return table;
             }
 

--- a/mason/jobs/log.mas
+++ b/mason/jobs/log.mas
@@ -19,13 +19,10 @@ $sp_person_id
 <& /util/import_javascript.mas, entries => ["job"], classes => [] &>
 
 <div id ="job_log_div" style="display:none;">
-    <div style='display:flex;justify-content:center;'>
+    <div class="tw:flex tw:gap-2.5 tw:flex-wrap tw:mb-3.75 tw:mt-2.5">
         <button id="clear_dead_jobs_button" class='btn btn-sm btn-primary'>Dismiss failed and timed out jobs</button>
-        <span style="display: inline-block; width: 100px;"></span>
         <button id="clear_finished_jobs_button" class='btn btn-sm btn-primary'>Dismiss finished and canceled jobs</button>
-        <span style="display: inline-block; width: 100px;"></span>
         <button id="clear_old_jobs_button" class='btn btn-sm btn-primary'>Dismiss all jobs older than</button> 
-        &nbsp;
         <select id="keep_recent_jobs_select">
             <option value='one_week'>One week</option>
             <option value='one_month'>One month</option>

--- a/mason/jobs/log.mas
+++ b/mason/jobs/log.mas
@@ -47,6 +47,7 @@ jQuery(document).ready(function (){
                 alert("Error fetching submitted jobs, check console.");
                 console.error(response.error);
             } else {
+                response.data.scrollX = true;
                 jQuery('#job_log_div').removeAttr('style');
                 jQuery('#user_job_log_table').DataTable(response.data);
                 console.log(response.data);

--- a/t/selenium2/03_dataset/tool_compatibility.t
+++ b/t/selenium2/03_dataset/tool_compatibility.t
@@ -16,6 +16,40 @@ my $dbh = $f->dbh();
 $d->while_logged_in_as("submitter", sub {
 
     # -------------------------------------------------------------------------
+    # Tool Compatibility for Datasets with Trials
+
+    my $dataset_name = "Trial.ToolCompatibility";
+
+    # Create small dataset using wizard for analysis
+    $d->get_ok("/breeders/search", "navigate to search wizard");
+    $d->click_ok('(//div[@class="panel-heading"]/select)[1]//option[@value="trials"]', 'xpath', 'select trials');
+    $d->click_ok('(//div[@class="panel-body"])[1]//a[contains(text(), "Kasese solgs trial")]//preceding-sibling::button' , 'xpath', 'add Kasese solgs trial');
+    $d->send_keys_ok("wizard-dataset-name", "class", "$dataset_name", "enter dataset name");
+    $d->click_ok("wizard-dataset-create", "class", "click create dataset");
+    $d->wait_for_alert_appear();
+    $d->accept_alert_ok("accept dataset summary alert");
+    my $dataset_id = $f->people_schema()->resultset("SpDataset")->find({ name => $dataset_name })->sp_dataset_id();
+
+    # Wait for tool compatibliity to be done
+    wait_for_tool_compatibility($dataset_id);
+
+    # Check job status in user profile
+    $d->click_ok("navbar_profile", "id", "click user profile");
+    $d->find_element_ok("//td[text()='tool_compatibility']/following-sibling::td[text()='finished']", 'xpath', 'tool_compatibility status is finished');
+
+    # Check tool compatibility values
+    $d->get_ok("/dataset/$dataset_id", "navigate to dataset page");
+    $d->find_element_ok("//b[contains(text(), 'Boxplotter')]/span[contains(\@class, 'glyphicon-ok')]", "xpath", "boxplotter status is ok");
+    $d->find_element_ok("//b[contains(text(), 'Correlation')]/span[contains(\@class, 'glyphicon-ok')]", "xpath", "correlation status is ok");
+    $d->find_element_ok("//b[contains(text(), 'Clustering')]/span[contains(\@class, 'glyphicon-warning')]", "xpath", "clustering status is warning");
+    $d->find_element_ok("//b[contains(text(), 'GWAS')]/span[contains(\@class, 'glyphicon-warning')]", "xpath", "gwas status is warning");
+    $d->find_element_ok("//b[contains(text(), 'Heritability')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "heritability status is fail");
+    $d->find_element_ok("//b[contains(text(), 'Mixed Models')]/span[contains(\@class, 'glyphicon-ok')]", "xpath", "mixed models status is ok");
+    $d->find_element_ok("//b[contains(text(), 'NIRS')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "nirs status is fail");
+    $d->find_element_ok("//b[contains(text(), 'Population Structure')]/span[contains(\@class, 'glyphicon-warning')]", "xpath", "population structure status is warning");
+    $d->find_element_ok("//b[contains(text(), 'Stability')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "stability status is fail");
+
+    # -------------------------------------------------------------------------
     # Tool Compatibility for Trials + Traits + Plots
 
     my $dataset_name = "Trials.Traits.Plots.ToolCompatibility";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR fixes a bug in which a job would always be stored in the DB as "failed" even when it ran successfully. The problem seemed to be that the job wasn't being constructed with a `finish_logfile`, so later queries could never get the status correctly.

<!-- If there are relevant issues, link them here: -->
- Dependent on #228 
- Resolves #227 

---

I cleaned up some graphical bugs along the way.

Add scrollX to the job submission table on the user's profile:

| Before | After |
| -- | -- |
| <img width="780" alt="image" src="https://github.com/user-attachments/assets/949cfc1f-6d65-4397-99a9-07ca8971ee04" /> | <img width="780"  alt="image" src="https://github.com/user-attachments/assets/b908e0f6-6ef7-4d7d-aa21-cbcce236b03e" /> |

Fix button wrapping overflow on the job submission table:

| Before | After |
| -- | -- |
| <img width="780" alt="image" src="https://github.com/user-attachments/assets/97a83bee-c948-4cc0-ab4e-8a518377c2f2" /> | <img width="780" alt="image" src="https://github.com/user-attachments/assets/8cf33a01-b4d8-4208-a1d6-0342ececb8e9" /> |

Styling changes to the Dataset summary page:
- Add better overflow handling. Use softening colors for border and fill to help with recursively nested elements.
- Sort the tools by name in the Tool Compatibility. Without sorting, they appear in a random order each time the page is loaded.

| Before | After |
| -- | -- |
| <img width="780" alt="image" src="https://github.com/user-attachments/assets/54795adb-60a0-414d-bf57-418ce6459048" /> | <img width="780" alt="image" src="https://github.com/user-attachments/assets/b83589c5-dbff-4cf0-a57b-351abf19287a" /> |

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
