### PR TITLE
fix(genotype): Incorrect genotype data relationships for certain stock types

### DIFF
--- a/js/source/modules/wizard-downloads.js
+++ b/js/source/modules/wizard-downloads.js
@@ -47,6 +47,15 @@ export function WizardDownloads(main_id,wizard){
     var accessions = categories.indexOf("accessions")!=-1?
       selections["accessions"]:
       [];
+    var plots = categories.indexOf("plots")!=-1?
+      selections["plots"]:
+      [];
+    var subplots = categories.indexOf("subplots")!=-1?
+      selections["subplots"]:
+      [];
+    var plants = categories.indexOf("plants")!=-1?
+      selections["plants"]:
+      [];
     // Use singular/non-pluralized form for compatibility
     var tissue_samples = categories.indexOf("tissue_sample")!=-1?
       selections["tissue_sample"]:
@@ -63,15 +72,28 @@ export function WizardDownloads(main_id,wizard){
     if (tissue_samples.length > 0){
       main.select(".wizard-download-genotypes-info")
       .attr("value",`${tissue_samples.length||"Too few"} tissue samples`);
+    } else if (plants.length > 0){
+      main.select(".wizard-download-genotypes-info")
+      .attr("value",`${tissue_samples.length||"Too few"} plants`);
+    } else if (subplots.length > 0){
+      main.select(".wizard-download-genotypes-info")
+      .attr("value",`${tissue_samples.length||"Too few"} subplots`);
+    } else if (plots.length > 0){
+      main.select(".wizard-download-genotypes-info")
+      .attr("value",`${tissue_samples.length||"Too few"} plots`);
     } else {
       main.select(".wizard-download-genotypes-info")
       .attr("value",`${accessions.length||"Too few"} accessions`);
     }
     main.selectAll(".wizard-download-genotypes")
-      .attr("disabled",accessions.length<1 && tissue_samples.length<1 ? true:null)
+      .attr("disabled",accessions.length<1 && tissue_samples.length<1
+        && plants.length<1 && subplots.length<1 && plots.length<1 ? true : null)
       .on("click",()=>{
         event.preventDefault();
         var accession_ids = accessions.map(d=>d.id);
+        var plot_ids = plots.map(d=>d.id);
+        var subplot_ids = subplots.map(d=>d.id);
+        var plant_ids = plants.map(d=>d.id);
         var tissue_sample_ids = tissue_samples.map(d=>d.id);
         var trial_ids = (selections["trials"]||[]).map(d=>d.id);
         var protocol_id = protocols.length==1?protocols[0].id:'';
@@ -89,8 +111,25 @@ export function WizardDownloads(main_id,wizard){
             return;
         }
         var url = document.location.origin+'/breeders/download_gbs_action';
-        var format = tissue_samples.length > 0 ? 'tissue_sample_ids' : 'accession_ids';
-        var ids = tissue_samples.length > 0 ? tissue_sample_ids : accession_ids;
+        var format = "accession_ids";
+        tissue_samples.length > 0 ? 'tissue_sample_ids' : 'accession_ids';
+        var ids = accession_ids;
+        if (tissue_samples.length > 0) {
+          ids = tissue_sample_ids;
+          format = 'tissue_sample_ids';
+        }
+        else if (plants.length > 0) {
+          ids = plant_ids;
+          format = "plant_ids";
+        }
+        else if (subplots.length > 0) {
+          ids = subplot_ids;
+          format = "subplot_ids";
+        }
+        else if (plots.length > 0) {
+          ids = plot_ids;
+          format = "plot_ids";
+        }
         openWindowWithPost(url, {
             ids: ids.join(","),
             protocol_id: protocol_id,

--- a/js/source/modules/wizard-downloads.js
+++ b/js/source/modules/wizard-downloads.js
@@ -112,7 +112,6 @@ export function WizardDownloads(main_id,wizard){
         }
         var url = document.location.origin+'/breeders/download_gbs_action';
         var format = "accession_ids";
-        tissue_samples.length > 0 ? 'tissue_sample_ids' : 'accession_ids';
         var ids = accession_ids;
         if (tissue_samples.length > 0) {
           ids = tissue_sample_ids;

--- a/lib/CXGN/Genotype/Download/VCF.pm
+++ b/lib/CXGN/Genotype/Download/VCF.pm
@@ -14,6 +14,9 @@ my $genotypes_search = CXGN::Genotype::Download::VCF->new({
     bcs_schema=>$schema,
     people_schema=>$people_schema,
     accession_list=>$accession_list,
+    plot_list=>$plot_list,
+    subplot_list=>$subplot_list,
+    plant_list=>$plant_list,
     tissue_sample_list=>$tissue_sample_list,
     trial_list=>$trial_list,
     protocol_id_list=>$protocol_id_list,
@@ -81,6 +84,21 @@ has 'markerprofile_id_list' => (
 );
 
 has 'accession_list' => (
+    isa => 'ArrayRef[Int]|Undef',
+    is => 'ro',
+);
+
+has 'plot_list' => (
+    isa => 'ArrayRef[Int]|Undef',
+    is => 'ro',
+);
+
+has 'subplot_list' => (
+    isa => 'ArrayRef[Int]|Undef',
+    is => 'ro',
+);
+
+has 'plant_list' => (
     isa => 'ArrayRef[Int]|Undef',
     is => 'ro',
 );
@@ -195,6 +213,9 @@ sub download {
     my $protocol_id_list = $self->protocol_id_list;
     my $markerprofile_id_list = $self->markerprofile_id_list;
     my $accession_list = $self->accession_list;
+    my $plot_list = $self->plot_list;
+    my $subplot_list = $self->subplot_list;
+    my $plant_list = $self->plant_list;
     my $tissue_sample_list = $self->tissue_sample_list;
     my $marker_name_list = $self->marker_name_list;
     my $genotypeprop_hash_select = $self->genotypeprop_hash_select;
@@ -215,6 +236,9 @@ sub download {
         people_schema=>$people_schema,
         cache_root=>$cache_root_dir,
         accession_list=>$accession_list,
+        plot_list=>$plot_list,
+        subplot_list=>$subplot_list,
+        plant_list=>$plant_list,
         tissue_sample_list=>$tissue_sample_list,
         trial_list=>$trial_list,
         protocol_id_list=>$protocol_id_list,

--- a/lib/CXGN/Genotype/Protocol.pm
+++ b/lib/CXGN/Genotype/Protocol.pm
@@ -166,6 +166,10 @@ sub BUILD {
     $h->execute($protocol_vcf_details_cvterm_id, $pcr_marker_protocolprop_cvterm_id, $geno_cvterm_id, $pcr_marker_protocol_cvterm_id, $self->nd_protocol_id);
     my ($nd_protocol_id, $nd_protocol_name, $value, $create_date, $description) = $h->fetchrow_array();
 
+    if (!defined $nd_protocol_name) {
+        die "NaturalDiversity::NdProtocol with id " . $self->nd_protocol_id . " does not exist.\n";
+    }
+
     my $map_details = $value ? decode_json $value : {};
     my $marker_names = $map_details->{marker_names} || [];
     my $assay_type = $map_details->{assay_type};

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -12,6 +12,9 @@ my $genotypes_search = CXGN::Genotype::Search->new({
     bcs_schema=>$schema,
     people_schema=>$people_schema,
     accession_list=>$accession_list,
+    plot_list=>$plot_list,
+    subplot_list=>$subplot_list,
+    plant_list=>$plant_list,
     tissue_sample_list=>$tissue_sample_list,
     trial_list=>$trial_list,
     protocol_id_list=>$protocol_id_list,
@@ -91,6 +94,21 @@ has 'markerprofile_id_list' => (
 );
 
 has 'accession_list' => (
+    isa => 'ArrayRef[Int]|Undef',
+    is => 'ro',
+);
+
+has 'plot_list' => (
+    isa => 'ArrayRef[Int]|Undef',
+    is => 'ro',
+);
+
+has 'subplot_list' => (
+    isa => 'ArrayRef[Int]|Undef',
+    is => 'ro',
+);
+
+has 'plant_list' => (
     isa => 'ArrayRef[Int]|Undef',
     is => 'ro',
 );
@@ -244,6 +262,11 @@ has '_plot_cvterm_id' => (
     is => 'rw'
 );
 
+has '_subplot_cvterm_id' => (
+    isa => 'Int',
+    is => 'rw'
+);
+
 has '_plant_cvterm_id' => (
     isa => 'Int',
     is => 'rw'
@@ -376,6 +399,9 @@ sub get_genotype_info {
     my $protocol_id_list = $self->protocol_id_list;
     my $markerprofile_id_list = $self->markerprofile_id_list;
     my $accession_list = $self->accession_list;
+    my $plot_list = $self->plot_list;
+    my $subplot_list = $self->subplot_list;
+    my $plant_list = $self->plant_list;
     my $tissue_sample_list = $self->tissue_sample_list;
     my $genotyping_plate_list = $self->genotyping_plate_list;
     my $marker_name_list = $self->marker_name_list;
@@ -405,7 +431,12 @@ sub get_genotype_info {
     my $accession_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'accession', 'stock_type')->cvterm_id();
     my $tissue_sample_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'tissue_sample', 'stock_type')->cvterm_id();
     my $plot_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'plot', 'stock_type')->cvterm_id();
+    my $subplot_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'subplot', 'stock_type')->cvterm_id();
     my $plant_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'plant', 'stock_type')->cvterm_id();
+
+    my $plot_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'plot_of', 'stock_relationship')->cvterm_id();
+    my $subplot_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'subplot_of', 'stock_relationship')->cvterm_id();
+    my $plant_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'plant_of', 'stock_relationship')->cvterm_id();
     my $tissue_sample_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'tissue_sample_of', 'stock_relationship')->cvterm_id();
 
     my @trials_accessions;
@@ -457,6 +488,27 @@ sub get_genotype_info {
         push @where_clause, " ( stock.stock_id in ($accession_sql) OR (accession_of_tissue_sample.stock_id in ($accession_sql) AND accession_of_tissue_sample.type_id = $accession_cvterm_id) ) ";
         push @where_clause, "stock.type_id in ($accession_cvterm_id, $tissue_sample_cvterm_id)";
     }
+    # Other stocks to fetch tissue samples of
+    my @parent_stock_list;
+    if ($plot_list && scalar(@$plot_list)>0) {
+        push @parent_stock_list, @$plot_list;
+    }
+    if ($subplot_list && scalar(@$subplot_list)>0) {
+        push @parent_stock_list, @$subplot_list;
+    }
+    if ($plant_list && scalar(@$plant_list)>0) {
+        push @parent_stock_list, @$plant_list;
+    }
+    if (scalar(@parent_stock_list)>0){
+        my $tissue_samples_rs = $schema->resultset('Stock::StockRelationship')->search({
+            object_id => {-in => @parent_stock_list},
+            type_id => $tissue_sample_of_cvterm_id
+        });
+        my @tissue_sample_ids = map { $_->subject_id() } $tissue_samples_rs->all();
+        if (scalar(@parent_stock_list)>0){
+            push @$tissue_sample_list, @tissue_sample_ids;
+        }
+    }
     if ($tissue_sample_list && scalar(@$tissue_sample_list)>0) {
         my $stock_sql = join ("," , @$tissue_sample_list);
         push @where_clause, "stock.stock_id in ($stock_sql)";
@@ -505,7 +557,7 @@ sub get_genotype_info {
         FROM stock
         JOIN cvterm AS stock_cvterm ON(stock.type_id = stock_cvterm.cvterm_id)
         LEFT JOIN stock_relationship ON(stock_relationship.subject_id=stock.stock_id AND stock_relationship.type_id = $tissue_sample_of_cvterm_id)
-        LEFT JOIN stock AS accession_of_tissue_sample ON(stock_relationship.object_id=accession_of_tissue_sample.stock_id)
+        JOIN stock AS accession_of_tissue_sample ON(stock_relationship.object_id=accession_of_tissue_sample.stock_id and accession_of_tissue_sample.type_id = $accession_cvterm_id)
         JOIN nd_experiment_stock ON(stock.stock_id=nd_experiment_stock.stock_id)
         JOIN nd_experiment USING(nd_experiment_id)
         JOIN nd_experiment_protocol USING(nd_experiment_id)
@@ -753,6 +805,9 @@ sub init_genotype_iterator {
     my $protocol_id_list = $self->protocol_id_list;
     my $markerprofile_id_list = $self->markerprofile_id_list;
     my $accession_list = $self->accession_list;
+    my $plot_list = $self->plot_list;
+    my $subplot_list = $self->subplot_list;
+    my $plant_list = $self->plant_list;
     my $tissue_sample_list = $self->tissue_sample_list;
     my $genotyping_plate_list = $self->genotyping_plate_list;
     my $marker_name_list = $self->marker_name_list;
@@ -789,10 +844,18 @@ sub init_genotype_iterator {
     $self->_tissue_sample_cvterm_id($tissue_sample_cvterm_id);
     my $plot_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'plot', 'stock_type')->cvterm_id();
     $self->_plot_cvterm_id($plot_cvterm_id);
+    my $subplot_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'subplot', 'stock_type')->cvterm_id();
+    $self->_subplot_cvterm_id($plot_cvterm_id);
+    my $plant_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'plant', 'stock_type')->cvterm_id();
+    $self->_plant_cvterm_id($plant_cvterm_id);
+
     my $plant_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'plant', 'stock_type')->cvterm_id();
     $self->_plant_cvterm_id($plant_cvterm_id);
     my $tissue_sample_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'tissue_sample_of', 'stock_relationship')->cvterm_id();
     $self->_tissue_sample_of_cvterm_id($tissue_sample_of_cvterm_id);
+    my $plot_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'plot_of', 'stock_relationship')->cvterm_id();
+    my $subplot_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'subplot_of', 'stock_relationship')->cvterm_id();
+    my $plant_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'plant_of', 'stock_relationship')->cvterm_id();
 
     my @trials_accessions;
     foreach (@$trial_list){
@@ -842,6 +905,27 @@ sub init_genotype_iterator {
         my $accession_sql = join ("," , @$accession_list);
         push @where_clause, " ( stock.stock_id in ($accession_sql) OR (accession_of_tissue_sample.stock_id in ($accession_sql) AND accession_of_tissue_sample.type_id = $accession_cvterm_id) ) ";
         push @where_clause, "stock.type_id in ($accession_cvterm_id, $tissue_sample_cvterm_id)";
+    }
+    # Other stocks to fetch tissue samples of
+    my @parent_stock_list;
+    if ($plot_list && scalar(@$plot_list)>0) {
+        push @parent_stock_list, @$plot_list;
+    }
+    if ($subplot_list && scalar(@$subplot_list)>0) {
+        push @parent_stock_list, @$subplot_list;
+    }
+    if ($plant_list && scalar(@$plant_list)>0) {
+        push @parent_stock_list, @$plant_list;
+    }
+    if (scalar(@parent_stock_list)>0){
+        my $tissue_samples_rs = $schema->resultset('Stock::StockRelationship')->search({
+            object_id => {-in => @parent_stock_list},
+            type_id => $tissue_sample_of_cvterm_id
+        });
+        my @tissue_sample_ids = map { $_->subject_id() } $tissue_samples_rs->all();
+        if (scalar(@parent_stock_list)>0){
+            push @$tissue_sample_list, @tissue_sample_ids;
+        }
     }
     if ($tissue_sample_list && scalar(@$tissue_sample_list)>0) {
         my $stock_sql = join ("," , @$tissue_sample_list);
@@ -954,7 +1038,7 @@ sub init_genotype_iterator {
         FROM stock
         JOIN cvterm AS stock_cvterm ON(stock.type_id = stock_cvterm.cvterm_id)
         LEFT JOIN stock_relationship ON(stock_relationship.subject_id=stock.stock_id AND stock_relationship.type_id = $tissue_sample_of_cvterm_id)
-        LEFT JOIN stock AS accession_of_tissue_sample ON(stock_relationship.object_id=accession_of_tissue_sample.stock_id)
+        JOIN stock AS accession_of_tissue_sample ON(stock_relationship.object_id=accession_of_tissue_sample.stock_id and accession_of_tissue_sample.type_id = $accession_cvterm_id)
         JOIN nd_experiment_stock ON(stock.stock_id=nd_experiment_stock.stock_id)
         JOIN nd_experiment USING(nd_experiment_id)
         JOIN nd_experiment_protocol USING(nd_experiment_id)
@@ -970,6 +1054,7 @@ sub init_genotype_iterator {
         $limit_clause
         $offset_clause;";
 
+    print STDERR "init_genotype_iterator query:\n$q\n";
     #print STDERR Dumper $q;
     my $h = $schema->storage->dbh()->prepare($q);
     $h->execute();

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -535,6 +535,9 @@ sub get_genotype_info {
         }
     }
 
+    # prevent partial duplicate records from LEFT JOIN
+    push @where_clause, "accession_of_tissue_sample.stock_id IS NOT NULL";
+
     my $where_clause = scalar(@where_clause)>0 ? " WHERE " . (join (" AND " , @where_clause)) : '';
 
     my $offset_clause = '';
@@ -557,7 +560,7 @@ sub get_genotype_info {
         FROM stock
         JOIN cvterm AS stock_cvterm ON(stock.type_id = stock_cvterm.cvterm_id)
         LEFT JOIN stock_relationship ON(stock_relationship.subject_id=stock.stock_id AND stock_relationship.type_id = $tissue_sample_of_cvterm_id)
-        JOIN stock AS accession_of_tissue_sample ON(stock_relationship.object_id=accession_of_tissue_sample.stock_id and accession_of_tissue_sample.type_id = $accession_cvterm_id)
+        LEFT JOIN stock AS accession_of_tissue_sample ON(stock_relationship.object_id=accession_of_tissue_sample.stock_id and accession_of_tissue_sample.type_id = $accession_cvterm_id)
         JOIN nd_experiment_stock ON(stock.stock_id=nd_experiment_stock.stock_id)
         JOIN nd_experiment USING(nd_experiment_id)
         JOIN nd_experiment_protocol USING(nd_experiment_id)
@@ -931,7 +934,6 @@ sub init_genotype_iterator {
         my $stock_sql = join ("," , @$tissue_sample_list);
         push @where_clause, "stock.stock_id in ($stock_sql)";
         push @where_clause, "stock.type_id = $tissue_sample_cvterm_id";
-        push @where_clause, "accession_of_tissue_sample.stock_id IS NOT NULL";
     }
     if ($markerprofile_id_list && scalar(@$markerprofile_id_list)>0) {
         my $markerprofile_sql = join ("," , @$markerprofile_id_list);
@@ -958,6 +960,9 @@ sub init_genotype_iterator {
             push @where_clause, "genotype_values.value \\@> $json_val"."::jsonb";
         }
     }
+
+    # prevent partial duplicate records from LEFT JOIN
+    push @where_clause, "accession_of_tissue_sample.stock_id IS NOT NULL";
 
     my $where_clause = scalar(@where_clause)>0 ? " WHERE " . (join (" AND " , @where_clause)) : '';
 

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -950,7 +950,7 @@ sub init_genotype_iterator {
         });
         my @tissue_sample_ids = map { $_->subject_id() } $tissue_samples_rs->all();
         push @$tissue_sample_list, @tissue_sample_ids;
-        $has_parent_stock_filter = 0;
+        $has_parent_stock_filter = 1;
     }
     if ($tissue_sample_list && scalar(@$tissue_sample_list)>0) {
         my $stock_sql = join ("," , @$tissue_sample_list);

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -314,22 +314,26 @@ has '_protocolprop_top_key_select_arr' => (
 
 has '_selected_protocol_marker_info' => (
     isa => 'Ref',
-    is => 'rw'
+    is => 'rw',
+    default => sub {{}}
 );
 
 has '_selected_protocol_top_key_info' => (
     isa => 'Ref',
-    is => 'rw'
+    is => 'rw',
+    default => sub {{}}
 );
 
 has '_genotypeprop_infos' => (
     isa => 'ArrayRef',
-    is => 'rw'
+    is => 'rw',
+    default => sub {[]}
 );
 
 has '_genotypeprop_infos_counter' => (
     isa => 'Int',
-    is => 'rw'
+    is => 'rw',
+    default => 0,
 );
 
 has '_genotypeprop_hash_select_arr' => (
@@ -539,7 +543,7 @@ sub get_genotype_info {
     # is no where_clause at this point, there is likely an upstream mistake
     # and we should return 0 genotypes, instead of returning all of them.
     if ($has_parent_stock_filter && scalar(@where_clause)==0) {
-        push @where_clause, "false";
+        return;
     }
 
     # Prevent partial duplicate records from LEFT JOIN
@@ -987,7 +991,7 @@ sub init_genotype_iterator {
     # is no where_clause at this point, there is likely an upstream mistake
     # and we should return 0 genotypes, instead of returning all of them.
     if ($has_parent_stock_filter && scalar(@where_clause)==0) {
-        push @where_clause, "false";
+        return;
     }
 
     # Prevent partial duplicate records from LEFT JOIN

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -590,6 +590,7 @@ sub get_genotype_info {
     my %genotype_hash;
     my %genotypeprop_hash;
     my %protocolprop_hash;
+    my %stock_synonyms = ();
     while (my ($stock_id, $igd_number_json, $protocol_id, $protocol_name, $stock_name, $stock_type_id, $stock_type_name, $genotype_id, $genotype_uniquename, $genotype_description, $project_id, $project_name, $project_description, $accession_id, $accession_uniquename, $full_count) = $h->fetchrow_array()) {
         my $igd_number_hash = $igd_number_json ? decode_json $igd_number_json : undef;
         my $igd_number = $igd_number_hash ? $igd_number_hash->{'igd number'} : undef;
@@ -621,15 +622,14 @@ sub get_genotype_info {
             }
         }
 
-        my $stock_object = CXGN::Stock::Accession->new({schema=>$self->bcs_schema, stock_id=>$stock_obj_id});
-
         push @genotype_id_array, $genotype_id;
+        $stock_synonyms{$stock_id} = [];
 
+        # Reminder: Synonyms gets added after this loop
         $genotype_hash{$genotype_id} = {
             markerProfileDbId => $genotype_id,
             germplasmDbId => $germplasmDbId,
             germplasmName => $germplasmName,
-            synonyms => $stock_object->synonyms,
             stock_id => $stock_id,
             stock_name => $stock_name,
             stock_type_id => $stock_type_id,
@@ -646,6 +646,21 @@ sub get_genotype_info {
         };
         $protocolprop_hash{$protocol_id}++;
         $total_count = $full_count;
+    }
+
+    # Get stockprop information outside of the while loop in one query
+    my @stock_ids = ( keys %stock_synonyms );
+    my $stockprop_rs = $self->bcs_schema->resultset('Stock::Stockprop')->search(
+        {'stock_id' => {-in => \@stock_ids}}
+    );
+    while (my $stockprop = $stockprop_rs->next()) {
+        my $stock_id = $stockprop->stock_id();
+        my $synonym = $stockprop->value();
+        push @{$stock_synonyms{$stock_id}}, $synonym;
+    }
+    foreach my $genotype_id ( keys %genotype_hash ) {
+        my $stock_id = $genotype_hash{$genotype_id}->{stock_id};
+        $genotype_hash{$genotype_id}->{synonyms} = $stock_synonyms{$stock_id};
     }
 
     my @found_protocolprop_ids = keys %protocolprop_hash;
@@ -1073,6 +1088,8 @@ sub init_genotype_iterator {
     $h->execute();
     my @genotypeprop_infos;
     my %seen_protocol_ids;
+
+    my %stock_synonyms = ();
     while (my ($stock_id, $igd_number_json, $protocol_id, $protocol_name, $stock_name, $stock_type_id, $stock_type_name, $genotype_id, $genotype_uniquename, $genotype_description, $project_id, $project_name, $project_description, $accession_id, $accession_uniquename, $full_count) = $h->fetchrow_array()) {
 
         my $germplasmName = '';
@@ -1104,13 +1121,13 @@ sub init_genotype_iterator {
             }
         }
 
-        my $stock_object = CXGN::Stock::Accession->new({schema=>$self->bcs_schema, stock_id=>$stock_obj_id});
+        $stock_synonyms{$stock_id} = [];
 
+        # Reminder: Synonyms gets added after this loop
         my %genotypeprop_info = (
             markerProfileDbId => $genotype_id,
             germplasmDbId => $germplasmDbId,
             germplasmName => $germplasmName,
-            synonyms => $stock_object->synonyms,
             stock_id => $stock_id,
             stock_name => $stock_name,
             stock_type_id => $stock_type_id,
@@ -1128,6 +1145,20 @@ sub init_genotype_iterator {
         );
         $seen_protocol_ids{$protocol_id}++;
         push @genotypeprop_infos, \%genotypeprop_info;
+    }
+
+    # Get stockprop information outside of the while loop in one query
+    my @stock_ids = ( keys %stock_synonyms );
+    my $stockprop_rs = $self->bcs_schema->resultset('Stock::Stockprop')->search(
+        {'stock_id' => {-in => \@stock_ids}}
+    );
+    while (my $stockprop = $stockprop_rs->next()) {
+        my $stock_id = $stockprop->stock_id();
+        my $synonym = $stockprop->value();
+        push @{$stock_synonyms{$stock_id}}, $synonym;
+    }
+    foreach my $info (@genotypeprop_infos) {
+        $info->{synonyms} = $stock_synonyms{$info->{stock_id}};
     }
 
     $self->_genotypeprop_infos(\@genotypeprop_infos);

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -931,6 +931,7 @@ sub init_genotype_iterator {
         my $stock_sql = join ("," , @$tissue_sample_list);
         push @where_clause, "stock.stock_id in ($stock_sql)";
         push @where_clause, "stock.type_id = $tissue_sample_cvterm_id";
+        push @where_clause, "accession_of_tissue_sample.stock_id IS NOT NULL";
     }
     if ($markerprofile_id_list && scalar(@$markerprofile_id_list)>0) {
         my $markerprofile_sql = join ("," , @$markerprofile_id_list);
@@ -1038,7 +1039,7 @@ sub init_genotype_iterator {
         FROM stock
         JOIN cvterm AS stock_cvterm ON(stock.type_id = stock_cvterm.cvterm_id)
         LEFT JOIN stock_relationship ON(stock_relationship.subject_id=stock.stock_id AND stock_relationship.type_id = $tissue_sample_of_cvterm_id)
-        JOIN stock AS accession_of_tissue_sample ON(stock_relationship.object_id=accession_of_tissue_sample.stock_id and accession_of_tissue_sample.type_id = $accession_cvterm_id)
+        LEFT JOIN stock AS accession_of_tissue_sample ON(stock_relationship.object_id=accession_of_tissue_sample.stock_id and accession_of_tissue_sample.type_id = $accession_cvterm_id)
         JOIN nd_experiment_stock ON(stock.stock_id=nd_experiment_stock.stock_id)
         JOIN nd_experiment USING(nd_experiment_id)
         JOIN nd_experiment_protocol USING(nd_experiment_id)

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -1054,7 +1054,6 @@ sub init_genotype_iterator {
         $limit_clause
         $offset_clause;";
 
-    print STDERR "init_genotype_iterator query:\n$q\n";
     #print STDERR Dumper $q;
     my $h = $schema->storage->dbh()->prepare($q);
     $h->execute();

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -535,9 +535,9 @@ sub get_genotype_info {
         }
     }
 
-    # prevent partial duplicate records from LEFT JOIN
-    push @where_clause, "accession_of_tissue_sample.stock_id IS NOT NULL";
-
+    # Prevent partial duplicate records from LEFT JOIN
+    # final records can either be accessions, or they can be a tissue sample that must be linked to an accession
+    push @where_clause, "(accession_of_tissue_sample.stock_id IS NOT NULL OR stock.type_id = $accession_cvterm_id)";
     my $where_clause = scalar(@where_clause)>0 ? " WHERE " . (join (" AND " , @where_clause)) : '';
 
     my $offset_clause = '';
@@ -961,9 +961,9 @@ sub init_genotype_iterator {
         }
     }
 
-    # prevent partial duplicate records from LEFT JOIN
-    push @where_clause, "accession_of_tissue_sample.stock_id IS NOT NULL";
-
+    # Prevent partial duplicate records from LEFT JOIN
+    # final records can either be accessions, or they can be a tissue sample that must be linked to an accession
+    push @where_clause, "(accession_of_tissue_sample.stock_id IS NOT NULL OR stock.type_id = $accession_cvterm_id)";
     my $where_clause = scalar(@where_clause)>0 ? " WHERE " . (join (" AND " , @where_clause)) : '';
 
     my $offset_clause = '';

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -197,7 +197,7 @@ has 'cache_expiry' => (
 has 'forbid_cache' => (
     isa => 'Bool',
     is => 'ro',
-    default => 0
+    default => 1
 );
 
 has 'prevent_transpose' => (

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -505,9 +505,7 @@ sub get_genotype_info {
             type_id => $tissue_sample_of_cvterm_id
         });
         my @tissue_sample_ids = map { $_->subject_id() } $tissue_samples_rs->all();
-        if (scalar(@parent_stock_list)>0){
-            push @$tissue_sample_list, @tissue_sample_ids;
-        }
+        push @$tissue_sample_list, @tissue_sample_ids;
     }
     if ($tissue_sample_list && scalar(@$tissue_sample_list)>0) {
         my $stock_sql = join ("," , @$tissue_sample_list);
@@ -533,6 +531,12 @@ sub get_genotype_info {
             my $json_val = encode_json $_;
             push @where_clause, "genotype_values.value \\@> $json_val"."::jsonb";
         }
+    }
+
+    # If there is no where_clause at this point, there is likely an upstream mistake
+    # and we should return 0 genotypes, instead of returning all of them.
+    if (scalar(@where_clause)==0) {
+        push @where_clause, "false";
     }
 
     # Prevent partial duplicate records from LEFT JOIN
@@ -926,9 +930,7 @@ sub init_genotype_iterator {
             type_id => $tissue_sample_of_cvterm_id
         });
         my @tissue_sample_ids = map { $_->subject_id() } $tissue_samples_rs->all();
-        if (scalar(@parent_stock_list)>0){
-            push @$tissue_sample_list, @tissue_sample_ids;
-        }
+        push @$tissue_sample_list, @tissue_sample_ids;
     }
     if ($tissue_sample_list && scalar(@$tissue_sample_list)>0) {
         my $stock_sql = join ("," , @$tissue_sample_list);
@@ -959,6 +961,12 @@ sub init_genotype_iterator {
             my $json_val = encode_json $_;
             push @where_clause, "genotype_values.value \\@> $json_val"."::jsonb";
         }
+    }
+
+    # If there is no where_clause at this point, there is likely an upstream mistake
+    # and we should return 0 genotypes, instead of returning all of them.
+    if (scalar(@where_clause)==0) {
+        push @where_clause, "false";
     }
 
     # Prevent partial duplicate records from LEFT JOIN

--- a/lib/CXGN/Genotype/Search.pm
+++ b/lib/CXGN/Genotype/Search.pm
@@ -499,6 +499,7 @@ sub get_genotype_info {
     if ($plant_list && scalar(@$plant_list)>0) {
         push @parent_stock_list, @$plant_list;
     }
+    my $has_parent_stock_filter = 0;
     if (scalar(@parent_stock_list)>0){
         my $tissue_samples_rs = $schema->resultset('Stock::StockRelationship')->search({
             object_id => {-in => @parent_stock_list},
@@ -506,6 +507,7 @@ sub get_genotype_info {
         });
         my @tissue_sample_ids = map { $_->subject_id() } $tissue_samples_rs->all();
         push @$tissue_sample_list, @tissue_sample_ids;
+        $has_parent_stock_filter = 1;
     }
     if ($tissue_sample_list && scalar(@$tissue_sample_list)>0) {
         my $stock_sql = join ("," , @$tissue_sample_list);
@@ -533,9 +535,10 @@ sub get_genotype_info {
         }
     }
 
-    # If there is no where_clause at this point, there is likely an upstream mistake
+    # If we were trying to filter by a parent stock (ex. plot, plant), but there
+    # is no where_clause at this point, there is likely an upstream mistake
     # and we should return 0 genotypes, instead of returning all of them.
-    if (scalar(@where_clause)==0) {
+    if ($has_parent_stock_filter && scalar(@where_clause)==0) {
         push @where_clause, "false";
     }
 
@@ -939,6 +942,7 @@ sub init_genotype_iterator {
     if ($plant_list && scalar(@$plant_list)>0) {
         push @parent_stock_list, @$plant_list;
     }
+    my $has_parent_stock_filter = 0;
     if (scalar(@parent_stock_list)>0){
         my $tissue_samples_rs = $schema->resultset('Stock::StockRelationship')->search({
             object_id => {-in => @parent_stock_list},
@@ -946,6 +950,7 @@ sub init_genotype_iterator {
         });
         my @tissue_sample_ids = map { $_->subject_id() } $tissue_samples_rs->all();
         push @$tissue_sample_list, @tissue_sample_ids;
+        $has_parent_stock_filter = 0;
     }
     if ($tissue_sample_list && scalar(@$tissue_sample_list)>0) {
         my $stock_sql = join ("," , @$tissue_sample_list);
@@ -978,9 +983,10 @@ sub init_genotype_iterator {
         }
     }
 
-    # If there is no where_clause at this point, there is likely an upstream mistake
+    # If we were trying to filter by a parent stock (ex. plot, plant), but there
+    # is no where_clause at this point, there is likely an upstream mistake
     # and we should return 0 genotypes, instead of returning all of them.
-    if (scalar(@where_clause)==0) {
+    if ($has_parent_stock_filter && scalar(@where_clause)==0) {
         push @where_clause, "false";
     }
 

--- a/lib/SGN/Controller/AJAX/Search/Genotype.pm
+++ b/lib/SGN/Controller/AJAX/Search/Genotype.pm
@@ -49,11 +49,15 @@ sub genotyping_data_search_GET : Args(0) {
     my $limit = $c->req->param('length');
     my $offset = $c->req->param('start');
 
+
     my $genotypes_search = CXGN::Genotype::Search->new({
         bcs_schema=>$bcs_schema,
         people_schema=>$people_schema,
         cache_root=>$c->config->{cache_file_path},
         accession_list=>$clean_inputs->{accession_id_list},
+        plot_list=>$clean_inputs->{plot_list},
+        subplot_list=>$clean_inputs->{subplot_list},
+        plant_list=>$clean_inputs->{plant_list},
         tissue_sample_list=>$clean_inputs->{tissue_sample_id_list},
         genotype_data_project_list=>$clean_inputs->{genotyping_data_project_id_list},
         protocol_id_list=>$clean_inputs->{protocol_id_list},

--- a/lib/SGN/Controller/AJAX/Stock.pm
+++ b/lib/SGN/Controller/AJAX/Stock.pm
@@ -2313,6 +2313,7 @@ sub get_stock_datatables_genotype_data_GET  {
     my $c = shift;
     my $limit = $c->req->param('length') || 1000;
     my $offset = $c->req->param('start') || 0;
+    my $forbid_cache = $c->req->param('forbid_cache') || 0;
     my $stock_id = $c->stash->{stock_row}->stock_id();
 
     my $schema = $c->dbic_schema("Bio::Chado::Schema", 'sgn_chado');
@@ -2324,12 +2325,19 @@ sub get_stock_datatables_genotype_data_GET  {
         bcs_schema=>$schema,
         people_schema=>$people_schema,
         cache_root=>$c->config->{cache_file_path},
+        forbid_cache=>$forbid_cache,
         genotypeprop_hash_select=>[],
         protocolprop_top_key_select=>[],
         protocolprop_marker_hash_select=>[]
     );
     if ($stock_type eq 'accession') {
         $genotype_search_params{accession_list} = [$stock_id];
+    } elsif ($stock_type eq 'plot') {
+        $genotype_search_params{plot_list} = [$stock_id];
+    } elsif ($stock_type eq 'subplot') {
+        $genotype_search_params{subplot_list} = [$stock_id];
+    } elsif ($stock_type eq 'plant') {
+        $genotype_search_params{plant_list} = [$stock_id];
     } elsif ($stock_type eq 'tissue_sample') {
         $genotype_search_params{tissue_sample_list} = [$stock_id];
     }

--- a/lib/SGN/Controller/BreedersToolbox/Download.pm
+++ b/lib/SGN/Controller/BreedersToolbox/Download.pm
@@ -1234,7 +1234,7 @@ sub download_gbs_action : Path('/breeders/download_gbs_action') {
     my $sample_unit_level = $c->req->param("sample_unit_level") || "accession";
 
     my (@accession_ids, @accession_list, @accession_genotypes, @unsorted_markers, @trial_ids);
-    my (@tissue_sample_ids);
+    my (@plot_ids, @subplot_ids, @plant_ids, @tissue_sample_ids);
     my ($id_string, $protocol_id, $project_id, $trial_id_string);
     my $associated_protocol;
     my $accession_data = [];
@@ -1244,10 +1244,17 @@ sub download_gbs_action : Path('/breeders/download_gbs_action') {
         @trial_ids = split(',', $trial_id_string);
     }
 
-    if ($format eq 'accession_ids' || $format eq 'tissue_sample_ids') {       #use protocol id and ids supplied directly
+    # use protocol id and ids supplied directly
+    if ( $format ~~ ['accession_ids', 'plot_ids', 'subplot_ids', 'plant_ids', 'tissue_sample_ids'] ) {
         $id_string = $c->req->param("ids");
         if ($format eq 'accession_ids'){
             @accession_ids = split(',',$id_string);
+        } elsif ($format eq 'plot_ids'){
+            @plot_ids = split(',',$id_string);
+        } elsif ($format eq 'subplot_ids'){
+            @subplot_ids = split(',',$id_string);
+        } elsif ($format eq 'plant_ids'){
+            @plant_ids = split(',',$id_string);
         } elsif ($format eq 'tissue_sample_ids'){
             @tissue_sample_ids = split(',',$id_string);
         }
@@ -1330,6 +1337,9 @@ sub download_gbs_action : Path('/breeders/download_gbs_action') {
             people_schema=>$people_schema,
             cache_root_dir=>$c->config->{cache_file_path},
             accession_list=>\@accession_ids,
+            plot_list=>\@plot_ids,
+            subplot_list=>\@subplot_ids,
+            plant_list=>\@plant_ids,
             tissue_sample_list=>\@tissue_sample_ids,
             trial_list=>\@trial_ids,
             protocol_id_list=>\@protocol_list,

--- a/mason/stock/direct_genotypes.mas
+++ b/mason/stock/direct_genotypes.mas
@@ -29,7 +29,7 @@ jQuery(document).ready(function () {
             'processing': true,
             'serverSide': true,
             "scrollX": true,
-            'ajax': '/stock/<% $stock_id %>/datatables/genotype_data'
+            'ajax': '/stock/<% $stock_id %>/datatables/genotype_data?forbid_cache=1'
         });
     });
 

--- a/t/lib/Shared/Genotypes.pm
+++ b/t/lib/Shared/Genotypes.pm
@@ -61,6 +61,8 @@ sub create_tissue_sample_genotypes {
     my ($schema) = @_;
 
     my $accession = 'test_accession1';
+    my $plot_name_1 = 'test_trial25';
+    my $plot_name_2 = 'test_trial28';
     my $num_tissue_samples = 3;
     my $location = 'Cornell Biotech';
     my $breeding_program = 'test';
@@ -68,6 +70,11 @@ sub create_tissue_sample_genotypes {
 
     # Create Tissue Samples
     my $accession_id = $schema->resultset("Stock::Stock")->find({uniquename=>$accession})->stock_id();
+    my $plot_id_1 = $schema->resultset("Stock::Stock")->find({uniquename=>$plot_name_1})->stock_id();
+    my $plot_id_2 = $schema->resultset("Stock::Stock")->find({uniquename=>$plot_name_2})->stock_id();
+
+    my $plant_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant', 'stock_type')->cvterm_id();
+    my $plant_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant_of', 'stock_relationship')->cvterm_id();
 
     my $tissue_sample_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample', 'stock_type')->cvterm_id();
     my $tissue_type_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_type', 'stock_property')->cvterm_id();
@@ -90,18 +97,63 @@ sub create_tissue_sample_genotypes {
             type_id => $tissue_sample_cvterm_id,
             organism_id => $organism->organism_id,
         });
+        my $tissue_sample_id = $tissue_sample->stock_id();
         # Create tissue sample stock properties
         $schema->resultset("Stock::Stockprop")->find_or_create( {
-            stock_id => $tissue_sample->stock_id(),
+            stock_id => $tissue_sample_id,
             type_id => $tissue_type_cvterm_id,
             value => "leaf",
         });
-        # Create tissue sample stock relationships
+
+        # Link all 3 tissue samples to an accession
         $schema->resultset("Stock::StockRelationship")->find_or_create({
-            subject_id => $tissue_sample->stock_id(),
+            subject_id => $tissue_sample_id,
             object_id => $accession_id,
             type_id => $tissue_sample_of_cvterm_id,
         });
+        # Link only first two tissue samples to plot
+        if ($i <= 2){
+            $schema->resultset("Stock::StockRelationship")->find_or_create({
+                subject_id => $tissue_sample_id,
+                object_id => $plot_id_1,
+                type_id => $tissue_sample_of_cvterm_id,
+            });
+        }
+        # Link last tissue sample to a different plot + a plant
+        if ($i == 3){
+            # Create plant stock to harvest tissue sample from
+            my $plant_name = $accession . "_plant-" . ${i};
+            my $plant = $schema->resultset("Stock::Stock")->find_or_create({
+                uniquename => $plant_name,
+                name => $plant_name,
+                type_id => $plant_cvterm_id,
+                organism_id => $organism->organism_id,
+            });
+            my $plant_id = $plant->stock_id();
+            # Create plant stock relationships
+            $schema->resultset("Stock::StockRelationship")->find_or_create({
+                subject_id => $plant_id,
+                object_id => $accession_id,
+                type_id => $plant_of_cvterm_id,
+            });
+            # Reminder: plot and plant have backwards relationship
+            $schema->resultset("Stock::StockRelationship")->find_or_create({
+                subject_id => $plot_id_2,
+                object_id => $plant_id,
+                type_id => $plant_of_cvterm_id,
+            });
+            # Create tissue sample stock relationships
+            $schema->resultset("Stock::StockRelationship")->find_or_create({
+                subject_id => $tissue_sample_id,
+                object_id => $plot_id_2,
+                type_id => $tissue_sample_of_cvterm_id,
+            });
+            $schema->resultset("Stock::StockRelationship")->find_or_create({
+                subject_id => $tissue_sample_id,
+                object_id => $plant_id,
+                type_id => $tissue_sample_of_cvterm_id,
+            });
+        }
         push(@tissue_samples, $tissue_sample_name);
     }
 }

--- a/t/lib/Shared/Genotypes.pm
+++ b/t/lib/Shared/Genotypes.pm
@@ -10,6 +10,7 @@ use warnings;
 use Exporter qw(import);
 use LWP::UserAgent;
 use JSON;
+use SGN::Model::Cvterm;
 
 # Default exports
 our @EXPORT = qw/

--- a/t/selenium2/stock/genotypes.t
+++ b/t/selenium2/stock/genotypes.t
@@ -1,0 +1,167 @@
+
+use strict;
+
+use lib 't/lib';
+
+use Test::More qw| no_plan |;
+use SGN::Test::Fixture;
+use SGN::Test::WWW::WebDriver;
+use SGN::Test::WWW::Mechanize;
+use Shared::Genotypes qw |create_tissue_sample_genotypes upload_tissue_sample_genotypes|;
+
+my $d = SGN::Test::WWW::WebDriver->new();
+my $f = SGN::Test::Fixture->new();
+my $mech = SGN::Test::WWW::Mechanize->new;
+my $schema = $f->bcs_schema;
+
+# Create tissue samples and upload genotypes
+create_tissue_sample_genotypes($schema);
+my $response = upload_tissue_sample_genotypes($schema, $mech);
+ok($response->is_success, 'upload response is success');
+
+$d->while_logged_in_as("curator", sub {
+
+    # -------------------------------------------------------------------------
+    # Accession that is directly genotyped (no tissue sample intermediate)
+
+    my $stock_name = 'UG120180';
+    my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+    $d->get_ok("/stock/$stock_id/view", "navigate to accession stock page");
+    $d->click_ok('stock_genotypes_section_onswitch', 'id', "Expand genotypes section");
+    $d->wait_for_network_idle();
+    my $observed_tbody = $d->get_attribute_ok("//table[\@id='stock_direct_genotypes_datatable']/tbody", "xpath", "innerHTML", "get $stock_name genotype table");
+    my $expected_tbody = '
+    <tr>
+        <td><a href="/breeders_toolbox/trial/142">test_population2</a></td>
+        <td>test_population2</td>
+        <td>GBS ApeKI genotyping v4</td>
+        <td>Cassava SNP genotypes for stock 520 20 24 25 29 30 44 46 108 109 112 114 520name = UG120180, id = 39973)</td>
+        <td><a href="/stock/39973/genotypes?genotype_id=798">Download</a></td>
+    </tr>';
+    # Trim leading whitespace and line breaks
+    $expected_tbody =~ s/^[ ]+|\R//mg;
+    is($observed_tbody, $expected_tbody, "accession $stock_name has 1 expected genotypes");
+
+    # -------------------------------------------------------------------------
+    # Tissue samples that are genotyped
+
+    # Check that accession test_accession1 has 3 genotype records
+    my $stock_name = 'test_accession1';
+    my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+    $d->get_ok("/stock/$stock_id/view", "navigate to accession stock page");
+    $d->click_ok('stock_genotypes_section_onswitch', 'id', "Expand genotypes section");
+    $d->wait_for_network_idle();
+    my $observed_tbody = $d->get_attribute_ok("//table[\@id='stock_direct_genotypes_datatable']/tbody", "xpath", "innerHTML", "get $stock_name genotype table");
+    my $expected_tbody = '
+    <tr>
+        <td><a href="/breeders_toolbox/trial/166">Tissue Sample Genotype Test</a></td>
+        <td>Test uploading genotypes to tissue samples</td>
+        <td>Test Genotyping Protocol for Tissue Samples</td>
+        <td>SNP genotypes for stock (name = test_accession1_leaf-1, id = 41794)</td>
+        <td><a href="/stock/38840/genotypes?genotype_id=1064">Download</a></td>
+    </tr>
+    <tr>
+        <td><a href="/breeders_toolbox/trial/166">Tissue Sample Genotype Test</a></td>
+        <td>Test uploading genotypes to tissue samples</td>
+        <td>Test Genotyping Protocol for Tissue Samples</td>
+        <td>SNP genotypes for stock (name = test_accession1_leaf-2, id = 41795)</td>
+        <td><a href="/stock/38840/genotypes?genotype_id=1065">Download</a></td>
+    </tr>
+    <tr>
+        <td><a href="/breeders_toolbox/trial/166">Tissue Sample Genotype Test</a></td>
+        <td>Test uploading genotypes to tissue samples</td>
+        <td>Test Genotyping Protocol for Tissue Samples</td>
+        <td>SNP genotypes for stock (name = test_accession1_leaf-3, id = 41796)</td>
+        <td><a href="/stock/38840/genotypes?genotype_id=1066">Download</a></td>
+    </tr>';
+    # Trim leading whitespace and line breaks
+    $expected_tbody =~ s/^[ ]+|\R//mg;
+    is($observed_tbody, $expected_tbody, "accession $stock_name has 3 expected genotypes");
+
+    # Check that the plot test_trial25 has 2 genotype records
+    my $stock_name = 'test_trial25';
+    my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+    $d->get_ok("/stock/$stock_id/view", "navigate to plot stock page");
+    $d->click_ok('stock_genotypes_section_onswitch', 'id', "Expand genotypes section");
+    $d->wait_for_network_idle();
+    my $observed_tbody = $d->get_attribute_ok("//table[\@id='stock_direct_genotypes_datatable']/tbody", "xpath", "innerHTML", "get $stock_name genotype table");
+    my $expected_tbody = '
+    <tr>
+        <td><a href="/breeders_toolbox/trial/166">Tissue Sample Genotype Test</a></td>
+        <td>Test uploading genotypes to tissue samples</td>
+        <td>Test Genotyping Protocol for Tissue Samples</td>
+        <td>SNP genotypes for stock (name = test_accession1_leaf-1, id = 41794)</td>
+        <td><a href="/stock/38861/genotypes?genotype_id=1064">Download</a></td>
+    </tr>
+    <tr>
+        <td><a href="/breeders_toolbox/trial/166">Tissue Sample Genotype Test</a></td>
+        <td>Test uploading genotypes to tissue samples</td>
+        <td>Test Genotyping Protocol for Tissue Samples</td>
+        <td>SNP genotypes for stock (name = test_accession1_leaf-2, id = 41795)</td>
+        <td><a href="/stock/38861/genotypes?genotype_id=1065">Download</a></td>
+    </tr>';
+    # Trim leading whitespace and line breaks
+    $expected_tbody =~ s/^[ ]+|\R//mg;
+    is($observed_tbody, $expected_tbody, "plot $stock_name has 2 expected genotypes");
+
+    # Check that the plot test_trial28 has 1 genotype record
+    my $stock_name = 'test_trial28';
+    my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+    $d->get_ok("/stock/$stock_id/view", "navigate to plot stock page");
+    $d->click_ok('stock_genotypes_section_onswitch', 'id', "Expand genotypes section");
+    $d->wait_for_network_idle();
+    my $observed_tbody = $d->get_attribute_ok("//table[\@id='stock_direct_genotypes_datatable']/tbody", "xpath", "innerHTML", "get $stock_name genotype table");
+    my $expected_tbody = '
+    <tr>
+        <td><a href="/breeders_toolbox/trial/166">Tissue Sample Genotype Test</a></td>
+        <td>Test uploading genotypes to tissue samples</td>
+        <td>Test Genotyping Protocol for Tissue Samples</td>
+        <td>SNP genotypes for stock (name = test_accession1_leaf-3, id = 41796)</td>
+        <td><a href="/stock/38864/genotypes?genotype_id=1066">Download</a></td>
+    </tr>';
+    # Trim leading whitespace and line breaks
+    $expected_tbody =~ s/^[ ]+|\R//mg;
+    is($observed_tbody, $expected_tbody, "plot $stock_name has 1 expected genotype");
+
+    # Check that the plant test_accession1_plant-3 has 1 genotype records
+    my $stock_name = 'test_accession1_plant-3';
+    my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+    $d->get_ok("/stock/$stock_id/view", "navigate to plant stock page");
+    $d->click_ok('stock_genotypes_section_onswitch', 'id', "Expand genotypes section");
+    $d->wait_for_network_idle();
+    my $observed_tbody = $d->get_attribute_ok("//table[\@id='stock_direct_genotypes_datatable']/tbody", "xpath", "innerHTML", "get $stock_name genotype table");
+    my $expected_tbody = '
+    <tr>
+        <td><a href="/breeders_toolbox/trial/166">Tissue Sample Genotype Test</a></td>
+        <td>Test uploading genotypes to tissue samples</td>
+        <td>Test Genotyping Protocol for Tissue Samples</td>
+        <td>SNP genotypes for stock (name = test_accession1_leaf-3, id = 41796)</td>
+        <td><a href="/stock/41797/genotypes?genotype_id=1066">Download</a></td>
+    </tr>';
+    # Trim leading whitespace and line breaks
+    $expected_tbody =~ s/^[ ]+|\R//mg;
+    is($observed_tbody, $expected_tbody, "plant $stock_name has 1 expected genotype");
+
+    # Check that the tissue_sample test_accession1_leaf-3 has 1 genotype records
+    my $stock_name = 'test_accession1_leaf-3';
+    my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+    $d->get_ok("/stock/$stock_id/view", "navigate to tissue_sample stock page");
+    $d->click_ok('stock_genotypes_section_onswitch', 'id', "Expand genotypes section");
+    $d->wait_for_network_idle();
+    my $observed_tbody = $d->get_attribute_ok("//table[\@id='stock_direct_genotypes_datatable']/tbody", "xpath", "innerHTML", "get $stock_name genotype table");
+    my $expected_tbody = '
+    <tr>
+        <td><a href="/breeders_toolbox/trial/166">Tissue Sample Genotype Test</a></td>
+        <td>Test uploading genotypes to tissue samples</td>
+        <td>Test Genotyping Protocol for Tissue Samples</td>
+        <td>SNP genotypes for stock (name = test_accession1_leaf-3, id = 41796)</td>
+        <td><a href="/stock/41796/genotypes?genotype_id=1066">Download</a></td>
+    </tr>';
+    # Trim leading whitespace and line breaks
+    $expected_tbody =~ s/^[ ]+|\R//mg;
+    is($observed_tbody, $expected_tbody, "plant $stock_name has 1 expected genotype");
+});
+
+$d->driver->quit();
+$f->clean_up_db();
+done_testing();

--- a/t/selenium2/stock/genotypes.t
+++ b/t/selenium2/stock/genotypes.t
@@ -38,7 +38,6 @@ $d->while_logged_in_as("curator", sub {
         <td>Cassava SNP genotypes for stock 520 20 24 25 29 30 44 46 108 109 112 114 520name = UG120180, id = 39973)</td>
         <td><a href="/stock/39973/genotypes?genotype_id=798">Download</a></td>
     </tr>';
-    # Trim leading whitespace and line breaks
     $expected_tbody =~ s/^[ ]+|\R//mg;
     is($observed_tbody, $expected_tbody, "accession $stock_name has 1 expected genotypes");
 
@@ -74,7 +73,6 @@ $d->while_logged_in_as("curator", sub {
         <td>SNP genotypes for stock (name = test_accession1_leaf-3, id = 41796)</td>
         <td><a href="/stock/38840/genotypes?genotype_id=1066">Download</a></td>
     </tr>';
-    # Trim leading whitespace and line breaks
     $expected_tbody =~ s/^[ ]+|\R//mg;
     is($observed_tbody, $expected_tbody, "accession $stock_name has 3 expected genotypes");
 
@@ -100,7 +98,6 @@ $d->while_logged_in_as("curator", sub {
         <td>SNP genotypes for stock (name = test_accession1_leaf-2, id = 41795)</td>
         <td><a href="/stock/38861/genotypes?genotype_id=1065">Download</a></td>
     </tr>';
-    # Trim leading whitespace and line breaks
     $expected_tbody =~ s/^[ ]+|\R//mg;
     is($observed_tbody, $expected_tbody, "plot $stock_name has 2 expected genotypes");
 
@@ -119,7 +116,6 @@ $d->while_logged_in_as("curator", sub {
         <td>SNP genotypes for stock (name = test_accession1_leaf-3, id = 41796)</td>
         <td><a href="/stock/38864/genotypes?genotype_id=1066">Download</a></td>
     </tr>';
-    # Trim leading whitespace and line breaks
     $expected_tbody =~ s/^[ ]+|\R//mg;
     is($observed_tbody, $expected_tbody, "plot $stock_name has 1 expected genotype");
 
@@ -138,7 +134,6 @@ $d->while_logged_in_as("curator", sub {
         <td>SNP genotypes for stock (name = test_accession1_leaf-3, id = 41796)</td>
         <td><a href="/stock/41797/genotypes?genotype_id=1066">Download</a></td>
     </tr>';
-    # Trim leading whitespace and line breaks
     $expected_tbody =~ s/^[ ]+|\R//mg;
     is($observed_tbody, $expected_tbody, "plant $stock_name has 1 expected genotype");
 
@@ -157,9 +152,41 @@ $d->while_logged_in_as("curator", sub {
         <td>SNP genotypes for stock (name = test_accession1_leaf-3, id = 41796)</td>
         <td><a href="/stock/41796/genotypes?genotype_id=1066">Download</a></td>
     </tr>';
-    # Trim leading whitespace and line breaks
     $expected_tbody =~ s/^[ ]+|\R//mg;
     is($observed_tbody, $expected_tbody, "plant $stock_name has 1 expected genotype");
+
+    # -------------------------------------------------------------------------
+    # Accession with no genotypes
+
+    my $stock_name = 'IITA-TMS-IBA011412';
+    my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+    $d->get_ok("/stock/$stock_id/view", "navigate to accession stock page");
+    $d->click_ok('stock_genotypes_section_onswitch', 'id', "Expand genotypes section");
+    $d->wait_for_network_idle();
+    my $observed_tbody = $d->get_attribute_ok("//table[\@id='stock_direct_genotypes_datatable']/tbody", "xpath", "innerHTML", "get $stock_name genotype table");
+    my $expected_tbody = '
+    <tr>
+        <td colspan="5" class="dt-empty">No data available in table</td>
+    </tr>';
+    $expected_tbody =~ s/^[ ]+|\R//mg;
+    is($observed_tbody, $expected_tbody, "accession $stock_name has 0 expected genotypes");
+
+    # -------------------------------------------------------------------------
+    # Plot with no genotypes
+
+    my $stock_name = 'KASESE_TP2013_1000';
+    my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+    $d->get_ok("/stock/$stock_id/view", "navigate to plot stock page");
+    $d->click_ok('stock_genotypes_section_onswitch', 'id', "Expand genotypes section");
+    $d->wait_for_network_idle();
+    my $observed_tbody = $d->get_attribute_ok("//table[\@id='stock_direct_genotypes_datatable']/tbody", "xpath", "innerHTML", "get $stock_name genotype table");
+    my $expected_tbody = '
+    <tr>
+        <td colspan="5" class="dt-empty">No data available in table</td>
+    </tr>';
+    $expected_tbody =~ s/^[ ]+|\R//mg;
+    is($observed_tbody, $expected_tbody, "plot $stock_name has 0 expected genotypes");
+
 });
 
 $d->driver->quit();

--- a/t/unit_mech/AJAX/DownloadGenotypes.t
+++ b/t/unit_mech/AJAX/DownloadGenotypes.t
@@ -2,13 +2,19 @@
 use strict;
 use warnings;
 
+use lib 't/lib';
+
 use Test::More;
 use Test::WWW::Mechanize;
 use Data::Dumper;
 use JSON;
+use Shared::Genotypes qw |create_tissue_sample_genotypes upload_tissue_sample_genotypes|;
+use SGN::Test::Fixture;
 local $Data::Dumper::Indent = 0;
 
 my $mech = Test::WWW::Mechanize->new;
+my $f = SGN::Test::Fixture->new();
+my $schema = $f->bcs_schema;
 
 $mech->get_ok('http://localhost:3010/breeders/download_gbs_action?format=accession_ids&ids=39973&download_format=VCF&forbid_cache=1');
 my $response = $mech->content;
@@ -1544,4 +1550,59 @@ S12946_101555	0	1
 print STDERR Dumper $response;
 is($response, $expected_response, "test multiple genotype download dosage matrix");
 
+# Create tissue samples and upload genotypes
+create_tissue_sample_genotypes($schema);
+my $response = upload_tissue_sample_genotypes($schema, $mech);
+ok($response->is_success, 'upload response is success');
+my $message_hash = decode_json $response->decoded_content;
+my $protocol_id = $message_hash->{nd_protocol_id};
+
+# Check that the accession test_accession1 has 3 genotype records downloaded
+my $stock_name = 'test_accession1';
+my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+$mech->get_ok("http://localhost:3010/breeders/download_gbs_action?format=accession_ids&ids=$stock_id&download_format=VCF&forbid_cache=1&protocol_id=$protocol_id");
+my @expected = split "\n", '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_accession1_leaf-1	test_accession1_leaf-2	test_accession1_leaf-3
+1	10	S1_10	G	A	.	PASS	.	GT:AD:DP:GQ:PL:NT:DS	./.:0,0:0:.:1::NA	0/0:10,10:20:99:0,255,255:G,G:0	1/1:10,10:20:99:0,255,255:A,A:2';
+# Convert response to array of lines and remove header lines that start with '##'
+my @observed = grep(!/^\#\#/, split("\n", $mech->content));
+is_deeply(\@observed, \@expected, "accession test_accession1 has expected genotypes");
+
+# Check that the plot test_trial25 has 2 genotype records downloaded
+my $stock_name = 'test_trial25';
+my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+$mech->get_ok("http://localhost:3010/breeders/download_gbs_action?format=plot_ids&ids=$stock_id&download_format=VCF&forbid_cache=1&protocol_id=$protocol_id");
+my @expected = split "\n", '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_accession1_leaf-1	test_accession1_leaf-2
+1	10	S1_10	G	A	.	PASS	.	GT:AD:DP:GQ:PL:NT:DS	./.:0,0:0:.:1::NA	0/0:10,10:20:99:0,255,255:G,G:0';
+# Convert response to array of lines and remove header lines that start with '##'
+my @observed = grep(!/^\#\#/, split("\n", $mech->content));
+is_deeply(\@observed, \@expected, "plot test_trial25 has expected genotypes");
+
+# Check that the plot test_trial28 has 1 genotype records downloaded
+my $stock_name = 'test_trial28';
+my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+$mech->get_ok("http://localhost:3010/breeders/download_gbs_action?format=plant_ids&ids=$stock_id&download_format=VCF&forbid_cache=1&protocol_id=$protocol_id");
+my @expected = split "\n", '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_accession1_leaf-3
+1	10	S1_10	G	A	.	PASS	.	GT:AD:DP:GQ:PL:NT:DS	1/1:10,10:20:99:0,255,255:A,A:2';
+my @observed = grep(!/^\#\#/, split("\n", $mech->content));
+is_deeply(\@observed, \@expected, "plot test_trial28 has expected genotypes");
+
+# Check that the plant test_accession1_plant-3 has 1 genotype records downloaded
+my $stock_name = 'test_accession1_plant-3';
+my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+$mech->get_ok("http://localhost:3010/breeders/download_gbs_action?format=plant_ids&ids=$stock_id&download_format=VCF&forbid_cache=1&protocol_id=$protocol_id");
+my @expected = split "\n", '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_accession1_leaf-3
+1	10	S1_10	G	A	.	PASS	.	GT:AD:DP:GQ:PL:NT:DS	1/1:10,10:20:99:0,255,255:A,A:2';
+my @observed = grep(!/^\#\#/, split("\n", $mech->content));
+is_deeply(\@observed, \@expected, "plant test_accession1_plant-3 has expected genotypes");
+
+# Check that the plant test_accession1_leaf-3 has 1 genotype records downloaded
+my $stock_name = 'test_accession1_leaf-3';
+my $stock_id = $schema->resultset('Stock::Stock')->find( { uniquename => $stock_name })->stock_id();
+$mech->get_ok("http://localhost:3010/breeders/download_gbs_action?format=tissue_sample_ids&ids=$stock_id&download_format=VCF&forbid_cache=1&protocol_id=$protocol_id");
+my @expected = split "\n", '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_accession1_leaf-3
+1	10	S1_10	G	A	.	PASS	.	GT:AD:DP:GQ:PL:NT:DS	1/1:10,10:20:99:0,255,255:A,A:2';
+my @observed = grep(!/^\#\#/, split("\n", $mech->content));
+is_deeply(\@observed, \@expected, "tissue_sample test_accession1_leaf-3 has expected genotypes");
+
+$f->clean_up_db();
 done_testing();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR fixes a bug in which the genotypes belonging to a stock would be incorrect on the stock detail page. It also adds a signficant performance improvement for querying genotypes.

<!-- If there are relevant issues, link them here: -->
- Resolves #157 

## Genotype Relationships

The core problem seemed to be that the existing logic assumed the user was only ever querying for genotypes by stock types of `accession` or `tissue_sample`. This led to strange behavior when searching by other stock types, namely `plot`, `subplot`, and `plant`. The fix was to make sure that the genotype search logic was handled correctly for all these stock types.

Reminder of the stock hierarchy:
`accession` -> `plot` -> `subplot` -> `plant` -> `tissue_sample`

For some enhanced interactive testing in the UI, I put a long running sleep in `t/selenium2/breeders/breeder_search.t` (ex. `sleep(1000000)`) and then ran the following:

```bash
./run_test -s t/selenium2/breeders/breeder_search.t
```

Which will load the genotyping protocol **Test Genotyping Protocol for Tissue Samples** which has genotyped tissue samples, plots, plants, etc.


| Before | After |
| -- | -- |
| plot `test_trial25` is incorrectly associated with all genotypes in db | plot `test_trial25` is correctly associated with 2 genotyped tissue samples |
| <img width="540" alt="image" src="https://github.com/user-attachments/assets/f588ac4e-b42a-4d6b-9ec1-d7811639c9c5" /> | <img width="540"  alt="image" src="https://github.com/user-attachments/assets/ec9e3232-dd61-4beb-a88f-975f90a62206" /> |

## Genotype Search Performance

This PR also contributes a significant improvement in the performance the backend functions that query for genotype records (`init_genotype_iterator` and `get_genotype_info`). Previously, querying 500 genotypes took 10 seconds. Now, it is almost instant. The problem was small postgres queries running inside a loop.

I am also proposing to change the default behavior of genotype searches to _not_ use a file cache. I think the use of a file cache was a bandaid to handle the excessive postgres calls, which shouldn't be necessary right now. I also find it very confusing to troubleshoot when a backend call is querying the database vs. looking for a cached file.

Here is an example from the test fixture database, the genotyping protocol **GBS ApeKI genotyping v4**:
| Before | After |
| -- | -- |
| Takes about 10 seconds to load when you click the button to "Refresh Results" | Loads instantly. |
| <img width="649" height="478" alt="image" src="https://github.com/user-attachments/assets/3360e4a6-86e0-4e6f-8780-93003cbf0a46" /> | <img width="649" height="481" alt="image" src="https://github.com/user-attachments/assets/56d1400b-cbc0-48bb-bda4-8f3bf92cfe96" /> |

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [x] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
