### PR TITLE
fix(styles): improve well and table margins

### DIFF
--- a/mason/analyses/analysis_details.mas
+++ b/mason/analyses/analysis_details.mas
@@ -10,7 +10,7 @@ $trial_stock_type
 $analysis_metadata
 </%args>
 
-<div class="row flex-wrap-row">
+<div class="flex-wrap-row">
     <div class="flex-wrap-col">
 
         <table class="table table-hover table-bordered table-trial-details" >

--- a/mason/analyses/model_detail_page_section.mas
+++ b/mason/analyses/model_detail_page_section.mas
@@ -9,7 +9,7 @@ $model_files => {}
 $identifier_prefix
 </%args>
 
-<div class="row flex-wrap-row">
+<div class="flex-wrap-row">
     <div class="flex-wrap-col">
 
         <table class="table table-hover table-bordered table-trial-details" >

--- a/mason/analyses/model_details.mas
+++ b/mason/analyses/model_details.mas
@@ -4,7 +4,7 @@ $trial_name
 $analysis_metadata
 </%args>
 
-<div class="row flex-wrap-row">
+<div class="flex-wrap-row">
     <div class="flex-wrap-col">
 
         <table class="table table-hover table-bordered table-trial-details" >

--- a/mason/breeders_toolbox/cross/crossingtrial_details.mas
+++ b/mason/breeders_toolbox/cross/crossingtrial_details.mas
@@ -16,7 +16,7 @@ $trial_owner
 </%args>
 
 
-<div class="row flex-wrap-row">
+<div class="flex-wrap-row">
     <div class="flex-wrap-col">
 
         <table class="table table-hover table-bordered table-trial-details" >

--- a/mason/breeders_toolbox/genotyping_data_project/details.mas
+++ b/mason/breeders_toolbox/genotyping_data_project/details.mas
@@ -12,7 +12,7 @@ $genotype_data_type
 $trial_owner
 </%args>
 
-<div class="row flex-wrap-row">
+<div class="flex-wrap-row">
     <div class="flex-wrap-col">
 
         <table class="table table-hover table-bordered table-trial-details" >

--- a/mason/breeders_toolbox/genotyping_protocol/details.mas
+++ b/mason/breeders_toolbox/genotyping_protocol/details.mas
@@ -12,7 +12,7 @@ $marker_type
 $assay_type
 </%args>
 
-<div class="row flex-wrap-row">
+<div class="flex-wrap-row">
     <div class="flex-wrap-col">
 
         <table class="table table-hover table-bordered table-trial-details" >

--- a/mason/breeders_toolbox/genotyping_trials/detail.mas
+++ b/mason/breeders_toolbox/genotyping_trials/detail.mas
@@ -70,7 +70,7 @@ $assay_type => undef
 
             <div class="panel panel-default">
                 <div class="panel-body">
-                    <div class="row flex-wrap-row">
+                    <div class="flex-wrap-row">
                         <div class="flex-wrap-col">
                             <table class="table table-bordered table-hover table-trial-details">
                                 <tbody>

--- a/mason/breeders_toolbox/trial.mas
+++ b/mason/breeders_toolbox/trial.mas
@@ -90,7 +90,7 @@ $project_id => undef
 %     $barcode_section_title = 'Generate barcode labels for plots or plants or accessions in this trial.';
 % }
 
-<div class="row flex-wrap-row">
+<div class="flex-wrap-row">
     <div class="flex-wrap-col">
         <& /page/detail_page_3_col_section.mas, icon_class => "glyphicon glyphicon-qrcode", title => $barcode_section_title, label_design_btn_id => "label_designer_link", legacy_barcode_btn_id => "generate_trial_barcode_link" &>
     </div>

--- a/mason/breeders_toolbox/trial/trial_details.mas
+++ b/mason/breeders_toolbox/trial/trial_details.mas
@@ -27,7 +27,7 @@ $latest_trial_activity => undef
 
 </%args>
 
-<div class="row flex-wrap-row">
+<div class="flex-wrap-row">
     <div class="flex-wrap-col">
 
         <table class="table table-hover table-bordered table-trial-details">

--- a/static/css/treeimprovementbase.css
+++ b/static/css/treeimprovementbase.css
@@ -273,6 +273,7 @@ Bootstrap
 .flex-wrap-row {
     display: flex;
     flex-wrap: wrap;
+    column-gap: var(--padding-md);
 }
 
 .flex-wrap-row > .flex-wrap-col {
@@ -615,7 +616,7 @@ td.infosectionsubtitle {
     background-color: var(--well-background-color);
     border: var(--well-border);
     border-radius: var(--border-radius);
-    margin: var(--padding-sm);
+    margin: var(--padding-sm) 0;
 }
 
 /*
@@ -839,8 +840,7 @@ Table
     border-collapse: separate;
     border: var(--well-border);
     border-radius: var(--border-radius);
-    margin: var(--padding-sm);
-    width: calc(100% - var(--padding-md));
+    margin: var(--padding-sm) 0;
 }
 
 .table tbody tr td, .table tbody tr th {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
- Remove the x-axis margins from tables and wells so they align with the content above/below them
- Add column gap to flex-wrap-row to compensate for the lost spacing on details pages
- Remove the bootstrap row class from flex-wrap-row elements as it isn't necessary and adds **::before** and **::after** elements in the DOM that create unwanted column gaps
- Remove the table `calc(100% - var(--padding-md))` width calculation which is no longer necessary

|Before|After|
|------|-----|
| <img width="563" height="412" alt="image" src="https://github.com/user-attachments/assets/07930efb-084a-42ba-ba01-0256e9002081" /> |<img width="578" height="419" alt="image" src="https://github.com/user-attachments/assets/f26069c7-c532-443b-8bf3-ac2d2e2ae33a" />|
|<img width="520" height="248" alt="image" src="https://github.com/user-attachments/assets/d4cae79c-f1ba-498b-a064-c29a1d9de3ce" /> |<img width="578" height="271" alt="image" src="https://github.com/user-attachments/assets/69114455-242c-44f2-92ab-c3c0f00c09f2" />|
|<img width="580" height="169" alt="image" src="https://github.com/user-attachments/assets/488075c1-f179-4bf4-bf23-7e480f24ffce" />|<img width="494" height="170" alt="image" src="https://github.com/user-attachments/assets/6d977570-f636-45a6-98ad-91561c0be70b" />|




<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
