### PR TITLE
widget: fix collapser running onclick function for onswitch and offsw…

### DIFF
--- a/lib/CXGN/Page/Widgets.pm
+++ b/lib/CXGN/Page/Widgets.pm
@@ -107,8 +107,8 @@ sub collapser {
 	my $initial_text = ($state eq "hid") ? $hide_state_linktext : $linktext;
 	my $href_attr = $alt_href ? qq|href="$alt_href"| : qq|href="javascript:void(0);"|;
 
-	my $onswitch_style = $linkstyle . ($state eq "hid") ? "" : "display: none";
-	my $offswitch_style = $linkstyle . ($state eq "hid") ? "display: none" : "";
+	my $onswitch_style = $linkstyle . (($state eq "hid") ? "" : "display: none");
+	my $offswitch_style = $linkstyle . (($state eq "hid") ? "display: none" : "");
 
 	my $esc_linktext = $linktext;
 	$esc_linktext =~ s/"/\\"/g;
@@ -127,8 +127,14 @@ sub collapser {
 	      transform: rotate(-90deg);
 	  }
 	</style>
-	<a class="collapser collapser_show collapsed" data-toggle="collapse" data-target="#${id}_content" target="$alt_target" $href_attr style="$onswitch_style;" id="${id}_onswitch"><span class="glyphicon glyphicon-chevron-down collapser-chevron"></span><span class="collapser-label">$initial_text</span></a>
-	<a class="collapser collapser_show" data-toggle="collapse" data-target="#${id}_content" target="$alt_target" $href_attr style="$offswitch_style;" id="${id}_offswitch"><span class="glyphicon glyphicon-chevron-down collapser-chevron"></span><span class="collapser-label">$initial_text</span></a>
+	<a class="collapser collapser_show collapsed" data-toggle="collapse" data-target="#${id}_content" target="$alt_target" $href_attr style="$onswitch_style;" id="${id}_onswitch">
+		<span class="glyphicon glyphicon-chevron-down collapser-chevron"></span>
+		<span class="collapser-label">$initial_text</span>
+	</a>
+	<a class="collapser collapser_show" data-toggle="collapse" data-target="#${id}_content" target="$alt_target" $href_attr style="$offswitch_style;" id="${id}_offswitch">
+		<span class="glyphicon glyphicon-chevron-down collapser-chevron"></span>
+		<span class="collapser-label">$initial_text</span>
+	</a>
 HTML
 
 	my $wrapped_content = <<HTML;
@@ -143,14 +149,18 @@ jQuery(document).ready(function() {
     var \$onswitch = jQuery('#${id}_onswitch');
     var \$offswitch = jQuery('#${id}_offswitch');
 
-    \$content.on('show.bs.collapse', function() {
+    \$content.on('show.bs.collapse', function(event) {
+        // When collapsers are nested, prevent propogation to parents
+        event.stopPropagation();
         \$onswitch.hide();
         \$offswitch.show();
         \$label.html("$esc_linktext");
         $show_save_js
     });
 
-    \$content.on('hide.bs.collapse', function() {
+    \$content.on('hide.bs.collapse', function(event) {
+        // When collapsers are nested, prevent propogation to parents
+        event.stopPropagation();
         \$offswitch.hide();
         \$onswitch.show();
         \$label.html("$esc_hide_state_linktext");

--- a/lib/CXGN/Page/Widgets.pm
+++ b/lib/CXGN/Page/Widgets.pm
@@ -103,7 +103,6 @@ sub collapser {
 	$hide_state_linktext ||= $linktext;
 
 	my $collapse_in = ($state eq "hid") ? "" : "in";
-	my $collapsed_state = ($state eq "hid") ? "collapsed" : "";
 	my $initial_text = ($state eq "hid") ? $hide_state_linktext : $linktext;
 	my $href_attr = $alt_href ? qq|href="$alt_href"| : qq|href="javascript:void(0);"|;
 

--- a/lib/CXGN/Page/Widgets.pm
+++ b/lib/CXGN/Page/Widgets.pm
@@ -104,9 +104,11 @@ sub collapser {
 
 	my $collapse_in = ($state eq "hid") ? "" : "in";
 	my $collapsed_state = ($state eq "hid") ? "collapsed" : "";
-	my $initial_id = ($state eq "hid") ? "${id}_onswitch" : "${id}_offswitch";
 	my $initial_text = ($state eq "hid") ? $hide_state_linktext : $linktext;
 	my $href_attr = $alt_href ? qq|href="$alt_href"| : qq|href="javascript:void(0);"|;
+
+	my $onswitch_style = $linkstyle . ($state eq "hid") ? "" : "display: none";
+	my $offswitch_style = $linkstyle . ($state eq "hid") ? "display: none" : "";
 
 	my $esc_linktext = $linktext;
 	$esc_linktext =~ s/"/\\"/g;
@@ -125,7 +127,8 @@ sub collapser {
 	      transform: rotate(-90deg);
 	  }
 	</style>
-	<a class="collapser collapser_show $collapsed_state" data-toggle="collapse" data-target="#${id}_content" target="$alt_target" $href_attr style="$linkstyle" id="$initial_id"><span class="glyphicon glyphicon-chevron-down collapser-chevron"></span><span class="collapser-label">$initial_text</span></a>
+	<a class="collapser collapser_show collapsed" data-toggle="collapse" data-target="#${id}_content" target="$alt_target" $href_attr style="$onswitch_style;" id="${id}_onswitch"><span class="glyphicon glyphicon-chevron-down collapser-chevron"></span><span class="collapser-label">$initial_text</span></a>
+	<a class="collapser collapser_show" data-toggle="collapse" data-target="#${id}_content" target="$alt_target" $href_attr style="$offswitch_style;" id="${id}_offswitch"><span class="glyphicon glyphicon-chevron-down collapser-chevron"></span><span class="collapser-label">$initial_text</span></a>
 HTML
 
 	my $wrapped_content = <<HTML;
@@ -137,15 +140,19 @@ jQuery(document).ready(function() {
     var \$content = jQuery('#${id}_content');
     var \$trigger = jQuery('a[data-target="#${id}_content"]');
     var \$label = \$trigger.find('.collapser-label');
+    var \$onswitch = jQuery('#${id}_onswitch');
+    var \$offswitch = jQuery('#${id}_offswitch');
 
     \$content.on('show.bs.collapse', function() {
-        \$trigger.attr('id', '${id}_offswitch');
+        \$onswitch.hide();
+        \$offswitch.show();
         \$label.html("$esc_linktext");
         $show_save_js
     });
 
     \$content.on('hide.bs.collapse', function() {
-        \$trigger.attr('id', '${id}_onswitch');
+        \$offswitch.hide();
+        \$onswitch.show();
         \$label.html("$esc_hide_state_linktext");
         $hide_save_js
     });


### PR DESCRIPTION
This PR fixes a bug in the collapser widget, where the onclick function would run for both the `onswitch` and `offswitch`.

To handle this centrally, I made two separate elements for the `onswitch` and `offswitch` components, so that they can be distinctly targeted by their ids when the document is loaded.


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->
- Resolves #242 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
