### PR TITLE
fix(genotyping): limit vcf headers in genotyping protocol table to 10 lines

### DIFF
--- a/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
+++ b/mason/breeders_toolbox/genotyping_trials/upload_genotyping_data_dialogs.mas
@@ -1225,18 +1225,34 @@ jQuery(document).ready(function(){
         'ajax': {
             'url':'/ajax/genotyping_data/projects?select_checkbox_name=upload_genotyping_data_project_select',
         },
+        'scrollX': true
     });
 
     var upload_genotyping_data_protocol_table = jQuery('#upload_genotyping_data_protocol_search_results').DataTable( {
         'ajax': {
             'url':'/ajax/genotyping_data/protocols?select_checkbox_name=upload_genotyping_data_protocol_select',
         },
+        'scrollX': true
     });
 
     var upload_mla_protocol_table = jQuery('#upload_mla_protocol_search_results').DataTable( {
         'ajax': {
             'url':'/ajax/genotyping_data/protocols?select_checkbox_name=upload_mla_protocol_select',
+            'dataSrc': json => {
+                const vcfHeaderIndex = 2;
+                const vcfHeaderMaxLines = 10;
+                return json.data.map(row => {
+                    return {
+                        ...row,
+                        [vcfHeaderIndex]: row[vcfHeaderIndex]
+                            .split(/<br\s*\/?>/)
+                            .splice(0, vcfHeaderMaxLines)
+                            .join('<br/>'),
+                    }
+                });
+            },
         },
+        'scrollX': true
     });
 
     jQuery('#upload_genotyping_data_project_missing_button').click(function(){


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Also adds scrollX to these tables.

- Closes #152 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
