### PR TITLE
styles(images): adjust wrapping on plot images and image edit tables

### DIFF
--- a/lib/CXGN/Page/Form/Static.pm
+++ b/lib/CXGN/Page/Form/Static.pm
@@ -580,7 +580,7 @@ sub as_table_string {
     my $string = qq { <br/><div class="panel panel-default"><table class="table table-hover"> };
     foreach my $f ($self->get_fields()) { 
 	if (ref($f)!~/hidden/i) { 
-	    $string .=  "<tr><td>".($f->get_display_name || '')."</td><td><b>".($f->render || '')."</b></td></tr>\n";
+	    $string .=  "<tr><td class=\"static-form-label-cell\">".($f->get_display_name || '')."</td><td class=\"static-form-value-cell\"><b>".($f->render || '')."</b></td></tr>\n";
 	}
     }
     $string .= qq { </table></div> };

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -4476,12 +4476,12 @@ sub retrieve_plot_image : Chained('trial') PathPart('retrieve_plot_images') Args
       my $image_page_ref = "<a href=\"$image_page\">$image_name</a>";
 
       my $colorbox =
-        qq|<a href="$image_img"  class="stock_image_group" rel="gallery-figures"><img src="$small_image" alt="$image_description" onclick="close_view_plot_image_dialog()"/></a> |;
+        qq|<a href="$image_img"  class="stock_image_group" rel="gallery-figures"><img src="$small_image" alt="$image_description" class="stock-image" onclick="close_view_plot_image_dialog()"/></a> |;
       my $fhtml =
-        qq|<tr><td width=120>|
+        qq|<tr><td class="stock-image-cell">|
           . $colorbox
             . $image_page_ref
-              . "</td><td>"
+              . "</td><td class=\"stock-image-description-cell\">"
                 . $image_description
                   . "</td></tr>";
       if ( $count < 3 ) { $image_html .= $fhtml; }

--- a/static/css/treeimprovementbase.css
+++ b/static/css/treeimprovementbase.css
@@ -508,6 +508,9 @@ Forms
     white-space: break-spaces;
 }
 
+.static-form-value-cell {
+    text-wrap: wrap;
+}
 
 
 /*
@@ -735,6 +738,19 @@ Miscellaneous
         padding-left: 0px;
         padding-top: var(--padding-xl);
     }
+}
+
+.stock-image-cell {
+    display: flex;
+    flex-direction: column;
+}
+
+.stock-image-description-cell {
+    padding-left: var(--padding-lg);
+}
+
+.stock-image {
+    max-width: 120px;
 }
 
 /*


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Fixes the text wrapping on the **Plot Images** and **Image data** tables:

|Before|After|
|------|-----|
|<img width="868" height="280" alt="image" src="https://github.com/user-attachments/assets/5454ca4b-7c32-45f2-a93c-ffb80deda33c" />|<img width="878" height="283" alt="Screenshot 2026-08-14 142858" src="https://github.com/user-attachments/assets/b045e36b-d296-4dce-b7e6-604c21be3559" />|
|<img width="1702" height="344" alt="Screenshot 2026-08-14 140348" src="https://github.com/user-attachments/assets/555a1d2d-82fb-4832-80ee-4ccb1401787f" />|<img width="1542" height="387" alt="Screenshot 2026-08-14 140314" src="https://github.com/user-attachments/assets/c6741a16-4098-4a2b-8fa3-5b1f38ef3561" />|




- Closes #245 

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
