### PR TITLE
feat(fieldmap): add secondary axis

### DIFF
--- a/db/00208/AddSecondaryAxisProjectProp.pm
+++ b/db/00208/AddSecondaryAxisProjectProp.pm
@@ -29,13 +29,13 @@ it under the same terms as Perl itself.
 
 =cut
 
-package AddNorthArrowAngleProjectProp;
+package AddSecondaryAxisProjectProp;
 
 use Moose;
 use Bio::Chado::Schema;
 extends 'CXGN::Metadata::Dbpatch';
 
-has '+description' => ( default => 'Adds north_arrow_angle cvterm to project_property cv' );
+has '+description' => ( default => 'Adds secondary_x_axis_label, secondary_y_axis_label, secondary_x_axis_values, and secondary_y_axis_values cvterms to project_property cv' );
 
 sub patch {
     my $self=shift;

--- a/db/00208/AddSecondaryAxisProjectProp.pm
+++ b/db/00208/AddSecondaryAxisProjectProp.pm
@@ -1,0 +1,56 @@
+#!/usr/bin/env perl
+
+=head1 NAME
+
+AddSecondaryAxisProjectProp.pm
+
+=head1 SYNOPSIS
+
+mx-run AddSecondaryAxisProjectProp [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+This patch adds the 'secondary_x_axis_label', 'secondary_y_axis_label', 'secondary_x_axis_values',
+and 'secondary_y_axis_values' cvterms to the 'project_property' cv.
+
+=head1 AUTHOR
+
+Seth Traverse <setraver@ualberta.ca>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2026 University of Alberta
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+package AddNorthArrowAngleProjectProp;
+
+use Moose;
+use Bio::Chado::Schema;
+extends 'CXGN::Metadata::Dbpatch';
+
+has '+description' => ( default => 'Adds north_arrow_angle cvterm to project_property cv' );
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " . $self->name . ".\n\nDescription:\n  " . $self->description . ".\n\nExecuted by:\n " . $self->username . " .";
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    my $schema = Bio::Chado::Schema->connect( sub { $self->dbh->clone } );
+	$schema->resultset("Cv::Cvterm")->create_with({ name => 'secondary_x_axis_label', cv => 'project_property' });
+	$schema->resultset("Cv::Cvterm")->create_with({ name => 'secondary_y_axis_label', cv => 'project_property' });
+	$schema->resultset("Cv::Cvterm")->create_with({ name => 'secondary_x_axis_values', cv => 'project_property' });
+	$schema->resultset("Cv::Cvterm")->create_with({ name => 'secondary_y_axis_values', cv => 'project_property' });
+
+    print "You're done!\n";
+}
+
+1;

--- a/js/source/entries/fieldmap.tsx
+++ b/js/source/entries/fieldmap.tsx
@@ -24,6 +24,7 @@ import { useView, ViewProvider } from '../include/fieldmap/contexts/ViewContext'
 import { HeatmapProvider } from '../include/fieldmap/contexts/HeatmapContext';
 import { GeoFieldMap } from '../include/fieldmap/components/GeoFieldMap';
 import { SecondaryAxisModal } from '../include/fieldmap/modals/SecondaryAxisModal';
+import { useLayoutConfig } from '../include/fieldmap/contexts/LayoutConfigContext';
 
 declare global {
     interface JQuery {
@@ -36,6 +37,11 @@ const FieldMap: React.FC<FieldMapProps> = ({
     hasSubplotEntries,
     hasPlantEntries,
 }) => {
+    const { secondaryAxis } = useLayoutConfig();
+    const hasSecondaryAxis = Boolean(secondaryAxis && (secondaryAxis.xLabel || secondaryAxis.yLabel || (secondaryAxis.xValues && secondaryAxis.xValues.length > 0) || (secondaryAxis.yValues && secondaryAxis.yValues.length > 0)));
+    const offsetX = hasSecondaryAxis ? 80 : 50;
+    const offsetY = hasSecondaryAxis ? 55 : 25;
+
     const {
         svgDimensions: { width: svgWidth, height: svgHeight },
     } = usePlotGrid();
@@ -106,7 +112,7 @@ const FieldMap: React.FC<FieldMapProps> = ({
                                 viewBox={`0 0 ${svgWidth} ${svgHeight}`}
                                 style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`, transformOrigin: '0 0' }}
                             >
-                                <g transform="translate(50, 25)">
+                                <g transform={`translate(${offsetX}, ${offsetY})`}>
                                     <PlotLayer />
                                     <LabelLayer />
                                 </g>

--- a/js/source/entries/fieldmap.tsx
+++ b/js/source/entries/fieldmap.tsx
@@ -23,6 +23,7 @@ import { ModalsProvider, useModals } from '../include/fieldmap/contexts/ModalsCo
 import { useView, ViewProvider } from '../include/fieldmap/contexts/ViewContext';
 import { HeatmapProvider } from '../include/fieldmap/contexts/HeatmapContext';
 import { GeoFieldMap } from '../include/fieldmap/components/GeoFieldMap';
+import { SecondaryAxisModal } from '../include/fieldmap/modals/SecondaryAxisModal';
 
 declare global {
     interface JQuery {
@@ -123,6 +124,7 @@ const FieldMap: React.FC<FieldMapProps> = ({
             <DeleteTraitModal />
             <DimensionsModal />
             <PlotDetailsModal />
+            <SecondaryAxisModal />
 
             <DownloadPlotOrderPanel
                 hasColAndRowNumbers={hasColAndRowNumbers}

--- a/js/source/entries/fieldmap.tsx
+++ b/js/source/entries/fieldmap.tsx
@@ -37,8 +37,7 @@ const FieldMap: React.FC<FieldMapProps> = ({
     hasSubplotEntries,
     hasPlantEntries,
 }) => {
-    const { secondaryAxis } = useLayoutConfig();
-    const hasSecondaryAxis = Boolean(secondaryAxis && (secondaryAxis.xLabel || secondaryAxis.yLabel || (secondaryAxis.xValues && secondaryAxis.xValues.length > 0) || (secondaryAxis.yValues && secondaryAxis.yValues.length > 0)));
+    const { hasSecondaryAxis } = useLayoutConfig();
     const offsetX = hasSecondaryAxis ? 80 : 50;
     const offsetY = hasSecondaryAxis ? 55 : 25;
 

--- a/js/source/include/fieldmap/components/FieldMapSettingsPanel.tsx
+++ b/js/source/include/fieldmap/components/FieldMapSettingsPanel.tsx
@@ -42,7 +42,7 @@ export const FieldMapSettingsPanel: React.FC<FieldMapSettingsPanelProps> = ({ })
         setShowDownloadCSVModal,
         setShowDimDialog,
         setShowDeleteTraitModal,
-        setShowSecondaryAxisDialog,
+        setShowSecondaryAxisModal,
     } = useModals();
 
     const {
@@ -131,7 +131,7 @@ export const FieldMapSettingsPanel: React.FC<FieldMapSettingsPanelProps> = ({ })
                 <button className="btn btn-default" onClick={transposeLayout} disabled={displayLinkedTrials} title="Transpose Display"><span className="glyphicon glyphicon-random"></span></button>
                 <button className="btn btn-default" onClick={rotateLayout} disabled={displayLinkedTrials} title="Rotate"><span className="glyphicon glyphicon-repeat"></span></button>
                 <button className="btn btn-default" onClick={() => setShowDimDialog(true)} disabled={displayLinkedTrials} title="Change Dimensions"><span className="glyphicon glyphicon-resize-full"></span></button>
-                <button className="btn btn-default" onClick={() => setShowSecondaryAxisDialog(true)} disabled={displayLinkedTrials} title="Change Secondary Axis"><span className="glyphicon glyphicon-indent-left"></span></button>
+                <button className="btn btn-default" onClick={() => setShowSecondaryAxisModal(true)} disabled={displayLinkedTrials} title="Change Secondary Axis"><span className="glyphicon glyphicon-indent-left"></span></button>
                 <button className="btn btn-default" onClick={() => setShowDownloadCSVModal(true)} title="Download Spatial Layout (CSV)"><span className="glyphicon glyphicon-save"></span></button>
                 <button className="btn btn-default" onClick={() => printFieldMap(selectedView, selectedViewLabel)} title="Print Fieldmap"><span className="glyphicon glyphicon-print"></span></button>
                 {selectedView !== 'fieldmap' && selectedView !== 'geofieldmap' && (

--- a/js/source/include/fieldmap/components/FieldMapSettingsPanel.tsx
+++ b/js/source/include/fieldmap/components/FieldMapSettingsPanel.tsx
@@ -41,7 +41,8 @@ export const FieldMapSettingsPanel: React.FC<FieldMapSettingsPanelProps> = ({ })
     const {
         setShowDownloadCSVModal,
         setShowDimDialog,
-        setShowDeleteTraitModal
+        setShowDeleteTraitModal,
+        setShowSecondaryAxisDialog,
     } = useModals();
 
     const {
@@ -127,11 +128,12 @@ export const FieldMapSettingsPanel: React.FC<FieldMapSettingsPanelProps> = ({ })
             </div>
 
             <div className="tw:flex tw:gap-2.5 tw:flex-wrap tw:mb-3.75 tw:w-full">
-                <button className="btn btn-default" onClick={transposeLayout} disabled={displayLinkedTrials}>Transpose Display</button>
-                <button className="btn btn-default" onClick={rotateLayout} disabled={displayLinkedTrials}>Rotate</button>
-                <button className="btn btn-default" onClick={() => setShowDimDialog(true)} disabled={displayLinkedTrials}>Change Dimensions</button>
-                <button className="btn btn-default" onClick={() => setShowDownloadCSVModal(true)}>Download Spatial Layout (CSV)</button>
-                <button className="btn btn-default" onClick={() => printFieldMap(selectedView, selectedViewLabel)}>Print Fieldmap</button>
+                <button className="btn btn-default" onClick={transposeLayout} disabled={displayLinkedTrials} title="Transpose Display"><span className="glyphicon glyphicon-random"></span></button>
+                <button className="btn btn-default" onClick={rotateLayout} disabled={displayLinkedTrials} title="Rotate"><span className="glyphicon glyphicon-repeat"></span></button>
+                <button className="btn btn-default" onClick={() => setShowDimDialog(true)} disabled={displayLinkedTrials} title="Change Dimensions"><span className="glyphicon glyphicon-resize-full"></span></button>
+                <button className="btn btn-default" onClick={() => setShowSecondaryAxisDialog(true)} disabled={displayLinkedTrials} title="Change Secondary Axis"><span className="glyphicon glyphicon-indent-left"></span></button>
+                <button className="btn btn-default" onClick={() => setShowDownloadCSVModal(true)} title="Download Spatial Layout (CSV)"><span className="glyphicon glyphicon-save"></span></button>
+                <button className="btn btn-default" onClick={() => printFieldMap(selectedView, selectedViewLabel)} title="Print Fieldmap"><span className="glyphicon glyphicon-print"></span></button>
                 {selectedView !== 'fieldmap' && selectedView !== 'geofieldmap' && (
                     <button className="btn btn-default" onClick={() => downloadHeatmapImage()}>Download Heatmap Image</button>
                 )}

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -21,6 +21,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
         secondaryAxis
     } = useLayoutConfig();
 
+    // Compute the displayed secondary axis values and labels based on the layout configuration
     const displayedSecondaryAxis = useMemo(() => {
         if (!secondaryAxis) return undefined;
 
@@ -34,6 +35,9 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
         };
 
         const getFill = (axis: 'x' | 'y', values: any[]) => {
+            if (isTransposed) {
+                axis = axis === 'x' ? 'y' : 'x';
+            }
             const countToFill = axis === 'x' ?
                 bounds.numCols - values.length :
                 bounds.numRows - values.length;

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -239,7 +239,9 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             {gridMatrix.map((row, rIdx) => {
                 const displayY = invertRows ? rIdx : renderBounds.numRows - rIdx - 1;
                 return row.map((plot, cIdx) => {
-                    if (plot.type !== 'data' || plot.additionalInfo?.isObsolete) return null;
+                    if (plot.type !== 'data' || plot.additionalInfo?.isObsolete) {
+                        return null;
+                    }
 
                     const displayXIdx = invertCols ? renderBounds.numCols - cIdx - 1 : cIdx;
                     const plotX = displayXIdx * 52;
@@ -247,7 +249,9 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
 
                     const coordKey = `${plot.observationUnitPosition?.positionCoordinateX}-${plot.observationUnitPosition?.positionCoordinateY}`;
                     const isOverlapping = !!overlappingPlots[coordKey];
-                    if (isOverlapping) return null;
+                    if (isOverlapping) {
+                        return null;
+                    }
 
                     let labelText = String(plot.observationUnitPosition?.observationLevel?.levelCode || '');
                     if (labelVar === 'germplasm') {
@@ -261,7 +265,9 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                         labelText = plot.crossName || '';
                     }
 
-                    if (!labelText) return null;
+                    if (!labelText) {
+                        return null;
+                    }
 
                     return (
                         <text

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -91,13 +91,13 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
 
     return (
         <g style={{ pointerEvents: 'none' }}>
-            {/* Column Axis Labels (Top and Bottom) */}
-            {Array.from({ length: bounds.numCols }).map((_, idx) => {
-                const colCoord = bounds.minCol + idx;
+            {/* Column Axis Values (Top and Bottom) */}
+            {Array.from({ length: bounds.numCols }).map((_, axisIdx) => {
+                const colCoord = bounds.minCol + axisIdx;
                 const colIdx = colCoord - renderBounds.minCol;
                 const displayX = (invertCols ? renderBounds.numCols - colIdx - 1 : colIdx) * 52 + 25;
                 return (
-                    <React.Fragment key={`col-lbl-grp-${idx}`}>
+                    <React.Fragment key={`col-lbl-grp-${colIdx}`}>
                         <text x={displayX} y={-10} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
                             {colCoord}
                         </text>
@@ -109,25 +109,29 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Column Axis Values (Top and Bottom) */}
-            {hasSecondaryAxis && displayedSecondaryAxis?.xValues && displayedSecondaryAxis.xValues.length > 0 && Array.from({ length: bounds.numCols }).map((_, idx) => {
-                const colCoord = bounds.minCol + idx;
+            {hasSecondaryAxis && displayedSecondaryAxis?.xValues && displayedSecondaryAxis.xValues.length > 0 && Array.from({ length: bounds.numCols }).map((_, axisIdx) => {
+                const colCoord = bounds.minCol + axisIdx;
                 const colIdx = colCoord - renderBounds.minCol;
                 const displayX = (invertCols ? renderBounds.numCols - colIdx - 1 : colIdx) * 52 + 25;
-                const secXVal = displayedSecondaryAxis.xValues[idx];
-                if (secXVal === undefined || isNaN(secXVal)) return null;
+
+                const axisValue = displayedSecondaryAxis.xValues[axisIdx];
+                if (axisValue === undefined) {
+                    return null;
+                }
+
                 return (
-                    <React.Fragment key={`sec-col-lbl-grp-${idx}`}>
+                    <React.Fragment key={`sec-col-lbl-grp-${colIdx}`}>
                         <text x={displayX} y={-26} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
-                            {secXVal}
+                            {axisValue}
                         </text>
                         <text x={displayX} y={renderBounds.numRows * 52 + 36} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
-                            {secXVal}
+                            {axisValue}
                         </text>
                     </React.Fragment>
                 );
             })}
 
-            {/* Secondary Column Axis Label / Title */}
+            {/* Secondary Column Axis Label */}
             {hasSecondaryAxis && displayedSecondaryAxis?.xLabel && (
                 <>
                     <text
@@ -153,46 +157,57 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                 </>
             )}
 
-            {/* Row Axis Labels (Left and Right) */}
-            {gridMatrix.map((row, rIdx) => {
-                const rCoord = renderBounds.minRow + rIdx;
-                const isDataRow = rCoord >= bounds.minRow && rCoord <= bounds.maxRow;
-                const displayY = invertRows ? rIdx : renderBounds.numRows - rIdx - 1;
-                if (!isDataRow) return null;
+            {/* Row Axis Values (Left and Right) */}
+            {gridMatrix.map((_, rowIdx) => {
+                const rowCoord = renderBounds.minRow + rowIdx;
+                const displayY = invertRows ? rowIdx : renderBounds.numRows - rowIdx - 1;
+
+                const isDataRow = rowCoord >= bounds.minRow && rowCoord <= bounds.maxRow;
+                if (!isDataRow) {
+                    return null;
+                }
+
                 return (
-                    <React.Fragment key={`row-lbl-grp-${rIdx}`}>
+                    <React.Fragment key={`row-lbl-grp-${rowIdx}`}>
                         <text x={-20} y={displayY * 52 + 30} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
-                            {rCoord}
+                            {rowCoord}
                         </text>
                         <text x={renderBounds.numCols * 52 + 20} y={displayY * 52 + 30} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
-                            {rCoord}
+                            {rowCoord}
                         </text>
                     </React.Fragment>
                 );
             })}
 
             {/* Secondary Row Axis Values (Left and Right) */}
-            {hasSecondaryAxis && displayedSecondaryAxis?.yValues && displayedSecondaryAxis.yValues.length > 0 && gridMatrix.map((row, rIdx) => {
-                const rCoord = renderBounds.minRow + rIdx;
-                const isDataRow = rCoord >= bounds.minRow && rCoord <= bounds.maxRow;
-                const displayY = invertRows ? rIdx : renderBounds.numRows - rIdx - 1;
-                if (!isDataRow) return null;
-                const rIdxData = rCoord - bounds.minRow;
-                const secYVal = displayedSecondaryAxis.yValues[rIdxData];
-                if (secYVal === undefined || isNaN(secYVal)) return null;
+            {hasSecondaryAxis && displayedSecondaryAxis?.yValues && displayedSecondaryAxis.yValues.length > 0 && gridMatrix.map((_, rowIdx) => {
+                const rowCoord = renderBounds.minRow + rowIdx;
+                const displayY = invertRows ? rowIdx : renderBounds.numRows - rowIdx - 1;
+
+                const isDataRow = rowCoord >= bounds.minRow && rowCoord <= bounds.maxRow;
+                if (!isDataRow) {
+                    return null;
+                }
+
+                const axisIdx = rowCoord - bounds.minRow;
+                const axisValue = displayedSecondaryAxis.yValues[axisIdx];
+                if (axisValue === undefined) {
+                    return null;
+                }
+
                 return (
-                    <React.Fragment key={`sec-row-lbl-grp-${rIdx}`}>
+                    <React.Fragment key={`sec-row-lbl-grp-${rowIdx}`}>
                         <text x={-40} y={displayY * 52 + 30} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
-                            {secYVal}
+                            {axisValue}
                         </text>
                         <text x={renderBounds.numCols * 52 + 40} y={displayY * 52 + 30} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
-                            {secYVal}
+                            {axisValue}
                         </text>
                     </React.Fragment>
                 );
             })}
 
-            {/* Secondary Row Axis Label / Title */}
+            {/* Secondary Row Axis Label */}
             {hasSecondaryAxis && displayedSecondaryAxis?.yLabel && (
                 <>
                     <text

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { usePlotGrid } from '../contexts/PlotGridContext';
 import { useLayoutConfig } from '../contexts/LayoutConfigContext';
 
@@ -9,7 +9,9 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
         bounds,
         renderBounds,
         gridMatrix,
-        overlappingPlots
+        overlappingPlots,
+        isTransposed,
+        mapRotation
     } = usePlotGrid();
     const {
         invertRows,
@@ -19,7 +21,47 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
         secondaryAxis
     } = useLayoutConfig();
 
-    const hasSecondaryAxis = Boolean(secondaryAxis && (secondaryAxis.xLabel || secondaryAxis.yLabel || (secondaryAxis.xValues && secondaryAxis.xValues.length > 0) || (secondaryAxis.yValues && secondaryAxis.yValues.length > 0)));
+    const displayedSecondaryAxis = useMemo(() => {
+        if (!secondaryAxis) return undefined;
+
+        let curX = {
+            label: secondaryAxis.xLabel || '',
+            values: secondaryAxis.xValues ? [...secondaryAxis.xValues] : []
+        };
+        let curY = {
+            label: secondaryAxis.yLabel || '',
+            values: secondaryAxis.yValues ? [...secondaryAxis.yValues] : []
+        };
+
+        let dispX = curX;
+        let dispY = curY;
+
+        if (mapRotation === 90) {
+            dispX = curY;
+            dispY = { label: curX.label, values: [...curX.values].reverse() };
+        } else if (mapRotation === 180) {
+            dispX = { label: curX.label, values: [...curX.values].reverse() };
+            dispY = { label: curY.label, values: [...curY.values].reverse() };
+        } else if (mapRotation === 270) {
+            dispX = { label: curY.label, values: [...curY.values].reverse() };
+            dispY = curX;
+        }
+
+        if (isTransposed) {
+            const temp = dispX;
+            dispX = dispY;
+            dispY = temp;
+        }
+
+        return {
+            xLabel: dispX.label,
+            yLabel: dispY.label,
+            xValues: dispX.values,
+            yValues: dispY.values
+        };
+    }, [secondaryAxis, mapRotation, isTransposed]);
+
+    const hasSecondaryAxis = Boolean(displayedSecondaryAxis && (displayedSecondaryAxis.xLabel || displayedSecondaryAxis.yLabel || (displayedSecondaryAxis.xValues && displayedSecondaryAxis.xValues.length > 0) || (displayedSecondaryAxis.yValues && displayedSecondaryAxis.yValues.length > 0)));
 
     return (
         <g style={{ pointerEvents: 'none' }}>
@@ -41,11 +83,11 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Column Axis Values (Top and Bottom) */}
-            {hasSecondaryAxis && secondaryAxis?.xValues && secondaryAxis.xValues.length > 0 && Array.from({ length: bounds.numCols }).map((_, idx) => {
+            {hasSecondaryAxis && displayedSecondaryAxis?.xValues && displayedSecondaryAxis.xValues.length > 0 && Array.from({ length: bounds.numCols }).map((_, idx) => {
                 const colCoord = bounds.minCol + idx;
                 const colIdx = colCoord - renderBounds.minCol;
                 const displayX = (invertCols ? renderBounds.numCols - colIdx - 1 : colIdx) * 52 + 25;
-                const secXVal = secondaryAxis.xValues[idx];
+                const secXVal = displayedSecondaryAxis.xValues[idx];
                 if (secXVal === undefined || isNaN(secXVal)) return null;
                 return (
                     <React.Fragment key={`sec-col-lbl-grp-${idx}`}>
@@ -60,7 +102,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Column Axis Label / Title */}
-            {hasSecondaryAxis && secondaryAxis?.xLabel && (
+            {hasSecondaryAxis && displayedSecondaryAxis?.xLabel && (
                 <>
                     <text
                         x={(renderBounds.numCols * 52) / 2}
@@ -70,7 +112,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                         fontWeight="bold"
                         fill="#000"
                     >
-                        {secondaryAxis.xLabel}
+                        {displayedSecondaryAxis.xLabel}
                     </text>
                     <text
                         x={(renderBounds.numCols * 52) / 2}
@@ -80,7 +122,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                         fontWeight="bold"
                         fill="#000"
                     >
-                        {secondaryAxis.xLabel}
+                        {displayedSecondaryAxis.xLabel}
                     </text>
                 </>
             )}
@@ -104,13 +146,13 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Row Axis Values (Left and Right) */}
-            {hasSecondaryAxis && secondaryAxis?.yValues && secondaryAxis.yValues.length > 0 && gridMatrix.map((row, rIdx) => {
+            {hasSecondaryAxis && displayedSecondaryAxis?.yValues && displayedSecondaryAxis.yValues.length > 0 && gridMatrix.map((row, rIdx) => {
                 const rCoord = renderBounds.minRow + rIdx;
                 const isDataRow = rCoord >= bounds.minRow && rCoord <= bounds.maxRow;
                 const displayY = invertRows ? rIdx : renderBounds.numRows - rIdx - 1;
                 if (!isDataRow) return null;
                 const rIdxData = rCoord - bounds.minRow;
-                const secYVal = secondaryAxis.yValues[rIdxData];
+                const secYVal = displayedSecondaryAxis.yValues[rIdxData];
                 if (secYVal === undefined || isNaN(secYVal)) return null;
                 return (
                     <React.Fragment key={`sec-row-lbl-grp-${rIdx}`}>
@@ -125,7 +167,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Row Axis Label / Title */}
-            {hasSecondaryAxis && secondaryAxis?.yLabel && (
+            {hasSecondaryAxis && displayedSecondaryAxis?.yLabel && (
                 <>
                     <text
                         x={-60}
@@ -136,7 +178,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                         fontWeight="bold"
                         fill="#000"
                     >
-                        {secondaryAxis.yLabel}
+                        {displayedSecondaryAxis.yLabel}
                     </text>
                     <text
                         x={renderBounds.numCols * 52 + 60}
@@ -147,7 +189,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                         fontWeight="bold"
                         fill="#000"
                     >
-                        {secondaryAxis.yLabel}
+                        {displayedSecondaryAxis.yLabel}
                     </text>
                 </>
             )}

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -48,10 +48,13 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             const countToFill = axis === 'x' ?
                 bounds.numCols - values.length :
                 bounds.numRows - values.length;
+            
+            // Truncate the values to fit within the bounds of the axis before reversing and left-padding
+            const truncated = values.slice(0, axis === 'x' ? bounds.numCols : bounds.numRows);
 
             return Array(Math.max(countToFill, 0))
                 .fill('')
-                .concat([...values].reverse());
+                .concat(truncated.reverse());
         }
 
         let dispX = curX;

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -25,11 +25,11 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
     const displayedSecondaryAxis = useMemo(() => {
         if (!secondaryAxis) return undefined;
 
-        let curX = {
+        const curX = {
             label: secondaryAxis.xLabel || '',
             values: secondaryAxis.xValues ? [...secondaryAxis.xValues] : []
         };
-        let curY = {
+        const curY = {
             label: secondaryAxis.yLabel || '',
             values: secondaryAxis.yValues ? [...secondaryAxis.yValues] : []
         };

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -71,7 +71,12 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
         };
     }, [secondaryAxis, mapRotation, isTransposed]);
 
-    const hasSecondaryAxis = Boolean(displayedSecondaryAxis && (displayedSecondaryAxis.xLabel || displayedSecondaryAxis.yLabel || (displayedSecondaryAxis.xValues && displayedSecondaryAxis.xValues.length > 0) || (displayedSecondaryAxis.yValues && displayedSecondaryAxis.yValues.length > 0)));
+    const hasSecondaryAxis = displayedSecondaryAxis && (
+        displayedSecondaryAxis.xLabel ||
+        displayedSecondaryAxis.yLabel ||
+        (displayedSecondaryAxis.xValues && displayedSecondaryAxis.xValues.length > 0) ||
+        (displayedSecondaryAxis.yValues && displayedSecondaryAxis.yValues.length > 0)
+    );
 
     return (
         <g style={{ pointerEvents: 'none' }}>

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -33,17 +33,27 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             values: secondaryAxis.yValues ? [...secondaryAxis.yValues] : []
         };
 
+        const getFill = (axis: 'x' | 'y', values: any[]) => {
+            const countToFill = axis === 'x' ?
+                bounds.numCols - values.length :
+                bounds.numRows - values.length;
+
+            return Array(Math.max(countToFill, 0))
+                .fill('')
+                .concat(values);
+        }
+
         let dispX = curX;
         let dispY = curY;
 
         if (mapRotation === 90) {
             dispX = curY;
-            dispY = { label: curX.label, values: [...curX.values].reverse() };
+            dispY = { label: curX.label, values: getFill('y', [...curX.values].reverse()) };
         } else if (mapRotation === 180) {
-            dispX = { label: curX.label, values: [...curX.values].reverse() };
-            dispY = { label: curY.label, values: [...curY.values].reverse() };
+            dispX = { label: curX.label, values: getFill('x', [...curX.values].reverse()) };
+            dispY = { label: curY.label, values: getFill('y', [...curY.values].reverse()) };
         } else if (mapRotation === 270) {
-            dispX = { label: curY.label, values: [...curY.values].reverse() };
+            dispX = { label: curY.label, values: getFill('x', [...curY.values].reverse()) };
             dispY = curX;
         }
 

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -11,9 +11,9 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
         dimensions,
         gridMatrix,
         overlappingPlots,
-        isTransposed,
-        mapRotation
+        axisOrientation
     } = usePlotGrid();
+
     const {
         invertRows,
         invertCols,
@@ -26,61 +26,25 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
     const displayedSecondaryAxis = useMemo(() => {
         if (!secondaryAxis) return undefined;
 
-        const curX = {
-            label: secondaryAxis.xLabel || '',
-            values: secondaryAxis.xValues ? [...secondaryAxis.xValues] : []
+        const getAxisDisplay = (
+            orientation: { source: 'x' | 'y'; reversed: boolean },
+            length: number
+        ) => {
+            const [label, configValues] = orientation.source === 'x' ?
+                [secondaryAxis.xLabel, secondaryAxis.xValues ?? []] :
+                [secondaryAxis.yLabel, secondaryAxis.yValues ?? []];
+
+            const values = Array.from({ length }, (_, i) => {
+                const idx = orientation.reversed ? length - 1 - i : i;
+                return configValues[idx] ?? '';
+            });
+
+            return { label, values };
         };
-        const curY = {
-            label: secondaryAxis.yLabel || '',
-            values: secondaryAxis.yValues ? [...secondaryAxis.yValues] : []
-        };
 
-        /**
-         * Reverse the values for the specified axis, left-padding them to align with the end of the axis.
-         * @param axis 'x' or 'y'
-         * @param values Array of values to reverse
-         * @returns Reversed and left-padded array of values
-         */
-        const reversed = (axis: 'x' | 'y', values: any[]) => {
-            if (isTransposed) {
-                axis = axis === 'x' ? 'y' : 'x';
-            }
-
-            const { rows, cols } = dimensions;
-
-            // Truncate the values to fit within the bounds of the axis before reversing and left-padding
-            const truncated = values.slice(0, axis === 'x' ? cols : rows);
-
-            const countToFill = axis === 'x' ?
-                cols - truncated.length :
-                rows - truncated.length;
-
-            const filled = Array(Math.max(countToFill, 0))
-                .fill('')
-                .concat(truncated.reverse());
-
-            return filled;
-        }
-
-        let dispX = curX;
-        let dispY = curY;
-
-        if (mapRotation === 90) {
-            dispX = curY;
-            dispY = { label: curX.label, values: reversed('y', curX.values) };
-        } else if (mapRotation === 180) {
-            dispX = { label: curX.label, values: reversed('x', curX.values) };
-            dispY = { label: curY.label, values: reversed('y', curY.values) };
-        } else if (mapRotation === 270) {
-            dispX = { label: curY.label, values: reversed('x', curY.values) };
-            dispY = curX;
-        }
-
-        if (isTransposed) {
-            const temp = dispX;
-            dispX = dispY;
-            dispY = temp;
-        }
+        const { cols, rows } = dimensions;
+        const dispX = getAxisDisplay(axisOrientation.x, cols || bounds.numCols);
+        const dispY = getAxisDisplay(axisOrientation.y, rows || bounds.numRows);
 
         return {
             xLabel: dispX.label,
@@ -88,7 +52,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             xValues: dispX.values,
             yValues: dispY.values
         };
-    }, [secondaryAxis, mapRotation, isTransposed, dimensions]);
+    }, [secondaryAxis, axisOrientation, dimensions, bounds]);
 
     const hasSecondaryAxis = displayedSecondaryAxis && (
         displayedSecondaryAxis.xLabel ||

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -8,6 +8,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
     const {
         bounds,
         renderBounds,
+        dimensions,
         gridMatrix,
         overlappingPlots,
         isTransposed,
@@ -45,16 +46,20 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                 axis = axis === 'x' ? 'y' : 'x';
             }
 
-            const countToFill = axis === 'x' ?
-                bounds.numCols - values.length :
-                bounds.numRows - values.length;
-            
-            // Truncate the values to fit within the bounds of the axis before reversing and left-padding
-            const truncated = values.slice(0, axis === 'x' ? bounds.numCols : bounds.numRows);
+            const { rows, cols } = dimensions;
 
-            return Array(Math.max(countToFill, 0))
+            // Truncate the values to fit within the bounds of the axis before reversing and left-padding
+            const truncated = values.slice(0, axis === 'x' ? cols : rows);
+
+            const countToFill = axis === 'x' ?
+                cols - truncated.length :
+                rows - truncated.length;
+
+            const filled = Array(Math.max(countToFill, 0))
                 .fill('')
                 .concat(truncated.reverse());
+
+            return filled;
         }
 
         let dispX = curX;
@@ -83,7 +88,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             xValues: dispX.values,
             yValues: dispY.values
         };
-    }, [secondaryAxis, mapRotation, isTransposed]);
+    }, [secondaryAxis, mapRotation, isTransposed, dimensions]);
 
     const hasSecondaryAxis = displayedSecondaryAxis && (
         displayedSecondaryAxis.xLabel ||

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -34,17 +34,24 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             values: secondaryAxis.yValues ? [...secondaryAxis.yValues] : []
         };
 
-        const getFill = (axis: 'x' | 'y', values: any[]) => {
+        /**
+         * Reverse the values for the specified axis, left-padding them to align with the end of the axis.
+         * @param axis 'x' or 'y'
+         * @param values Array of values to reverse
+         * @returns Reversed and left-padded array of values
+         */
+        const reversed = (axis: 'x' | 'y', values: any[]) => {
             if (isTransposed) {
                 axis = axis === 'x' ? 'y' : 'x';
             }
+
             const countToFill = axis === 'x' ?
                 bounds.numCols - values.length :
                 bounds.numRows - values.length;
 
             return Array(Math.max(countToFill, 0))
                 .fill('')
-                .concat(values);
+                .concat([...values].reverse());
         }
 
         let dispX = curX;
@@ -52,12 +59,12 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
 
         if (mapRotation === 90) {
             dispX = curY;
-            dispY = { label: curX.label, values: getFill('y', [...curX.values].reverse()) };
+            dispY = { label: curX.label, values: reversed('y', curX.values) };
         } else if (mapRotation === 180) {
-            dispX = { label: curX.label, values: getFill('x', [...curX.values].reverse()) };
-            dispY = { label: curY.label, values: getFill('y', [...curY.values].reverse()) };
+            dispX = { label: curX.label, values: reversed('x', curX.values) };
+            dispY = { label: curY.label, values: reversed('y', curY.values) };
         } else if (mapRotation === 270) {
-            dispX = { label: curY.label, values: getFill('x', [...curY.values].reverse()) };
+            dispX = { label: curY.label, values: reversed('x', curY.values) };
             dispY = curX;
         }
 

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -19,12 +19,15 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
         invertCols,
         labelVar,
         labelSize,
-        secondaryAxis
+        secondaryAxis,
+        hasSecondaryAxis
     } = useLayoutConfig();
 
     // Compute the displayed secondary axis values and labels based on the layout configuration
     const displayedSecondaryAxis = useMemo(() => {
-        if (!secondaryAxis) return undefined;
+        if (!hasSecondaryAxis || !secondaryAxis) {
+            return undefined;
+        }
 
         const getAxisDisplay = (
             orientation: { source: 'x' | 'y'; reversed: boolean },
@@ -52,14 +55,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             xValues: dispX.values,
             yValues: dispY.values
         };
-    }, [secondaryAxis, axisOrientation, dimensions, bounds]);
-
-    const hasSecondaryAxis = displayedSecondaryAxis && (
-        displayedSecondaryAxis.xLabel ||
-        displayedSecondaryAxis.yLabel ||
-        (displayedSecondaryAxis.xValues && displayedSecondaryAxis.xValues.length > 0) ||
-        (displayedSecondaryAxis.yValues && displayedSecondaryAxis.yValues.length > 0)
-    );
+    }, [hasSecondaryAxis, secondaryAxis, axisOrientation, dimensions, bounds]);
 
     return (
         <g style={{ pointerEvents: 'none' }}>
@@ -81,7 +77,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Column Axis Values (Top and Bottom) */}
-            {hasSecondaryAxis && displayedSecondaryAxis?.xValues && displayedSecondaryAxis.xValues.length > 0 && Array.from({ length: bounds.numCols }).map((_, axisIdx) => {
+            {displayedSecondaryAxis?.xValues?.length && Array.from({ length: bounds.numCols }).map((_, axisIdx) => {
                 const colCoord = bounds.minCol + axisIdx;
                 const colIdx = colCoord - renderBounds.minCol;
                 const displayX = (invertCols ? renderBounds.numCols - colIdx - 1 : colIdx) * 52 + 25;
@@ -104,7 +100,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Column Axis Label */}
-            {hasSecondaryAxis && displayedSecondaryAxis?.xLabel && (
+            {displayedSecondaryAxis?.xLabel && (
                 <>
                     <text
                         x={(renderBounds.numCols * 52) / 2}
@@ -152,7 +148,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Row Axis Values (Left and Right) */}
-            {hasSecondaryAxis && displayedSecondaryAxis?.yValues && displayedSecondaryAxis.yValues.length > 0 && gridMatrix.map((_, rowIdx) => {
+            {displayedSecondaryAxis?.yValues?.length && gridMatrix.map((_, rowIdx) => {
                 const rowCoord = renderBounds.minRow + rowIdx;
                 const displayY = invertRows ? rowIdx : renderBounds.numRows - rowIdx - 1;
 
@@ -180,7 +176,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Row Axis Label */}
-            {hasSecondaryAxis && displayedSecondaryAxis?.yLabel && (
+            {displayedSecondaryAxis?.yLabel && (
                 <>
                     <text
                         x={-60}

--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -15,8 +15,11 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
         invertRows,
         invertCols,
         labelVar,
-        labelSize
+        labelSize,
+        secondaryAxis
     } = useLayoutConfig();
+
+    const hasSecondaryAxis = Boolean(secondaryAxis && (secondaryAxis.xLabel || secondaryAxis.yLabel || (secondaryAxis.xValues && secondaryAxis.xValues.length > 0) || (secondaryAxis.yValues && secondaryAxis.yValues.length > 0)));
 
     return (
         <g style={{ pointerEvents: 'none' }}>
@@ -37,6 +40,51 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                 );
             })}
 
+            {/* Secondary Column Axis Values (Top and Bottom) */}
+            {hasSecondaryAxis && secondaryAxis?.xValues && secondaryAxis.xValues.length > 0 && Array.from({ length: bounds.numCols }).map((_, idx) => {
+                const colCoord = bounds.minCol + idx;
+                const colIdx = colCoord - renderBounds.minCol;
+                const displayX = (invertCols ? renderBounds.numCols - colIdx - 1 : colIdx) * 52 + 25;
+                const secXVal = secondaryAxis.xValues[idx];
+                if (secXVal === undefined || isNaN(secXVal)) return null;
+                return (
+                    <React.Fragment key={`sec-col-lbl-grp-${idx}`}>
+                        <text x={displayX} y={-26} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
+                            {secXVal}
+                        </text>
+                        <text x={displayX} y={renderBounds.numRows * 52 + 36} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
+                            {secXVal}
+                        </text>
+                    </React.Fragment>
+                );
+            })}
+
+            {/* Secondary Column Axis Label / Title */}
+            {hasSecondaryAxis && secondaryAxis?.xLabel && (
+                <>
+                    <text
+                        x={(renderBounds.numCols * 52) / 2}
+                        y={-42}
+                        textAnchor="middle"
+                        fontSize="12"
+                        fontWeight="bold"
+                        fill="#000"
+                    >
+                        {secondaryAxis.xLabel}
+                    </text>
+                    <text
+                        x={(renderBounds.numCols * 52) / 2}
+                        y={renderBounds.numRows * 52 + 52}
+                        textAnchor="middle"
+                        fontSize="12"
+                        fontWeight="bold"
+                        fill="#000"
+                    >
+                        {secondaryAxis.xLabel}
+                    </text>
+                </>
+            )}
+
             {/* Row Axis Labels (Left and Right) */}
             {gridMatrix.map((row, rIdx) => {
                 const rCoord = renderBounds.minRow + rIdx;
@@ -54,6 +102,55 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                     </React.Fragment>
                 );
             })}
+
+            {/* Secondary Row Axis Values (Left and Right) */}
+            {hasSecondaryAxis && secondaryAxis?.yValues && secondaryAxis.yValues.length > 0 && gridMatrix.map((row, rIdx) => {
+                const rCoord = renderBounds.minRow + rIdx;
+                const isDataRow = rCoord >= bounds.minRow && rCoord <= bounds.maxRow;
+                const displayY = invertRows ? rIdx : renderBounds.numRows - rIdx - 1;
+                if (!isDataRow) return null;
+                const rIdxData = rCoord - bounds.minRow;
+                const secYVal = secondaryAxis.yValues[rIdxData];
+                if (secYVal === undefined || isNaN(secYVal)) return null;
+                return (
+                    <React.Fragment key={`sec-row-lbl-grp-${rIdx}`}>
+                        <text x={-40} y={displayY * 52 + 30} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
+                            {secYVal}
+                        </text>
+                        <text x={renderBounds.numCols * 52 + 40} y={displayY * 52 + 30} textAnchor="middle" fontSize="11" fontWeight="bold" fill="#000">
+                            {secYVal}
+                        </text>
+                    </React.Fragment>
+                );
+            })}
+
+            {/* Secondary Row Axis Label / Title */}
+            {hasSecondaryAxis && secondaryAxis?.yLabel && (
+                <>
+                    <text
+                        x={-60}
+                        y={(renderBounds.numRows * 52) / 2}
+                        transform={`rotate(-90, -60, ${(renderBounds.numRows * 52) / 2})`}
+                        textAnchor="middle"
+                        fontSize="12"
+                        fontWeight="bold"
+                        fill="#000"
+                    >
+                        {secondaryAxis.yLabel}
+                    </text>
+                    <text
+                        x={renderBounds.numCols * 52 + 60}
+                        y={(renderBounds.numRows * 52) / 2}
+                        transform={`rotate(90, ${renderBounds.numCols * 52 + 60}, ${(renderBounds.numRows * 52) / 2})`}
+                        textAnchor="middle"
+                        fontSize="12"
+                        fontWeight="bold"
+                        fill="#000"
+                    >
+                        {secondaryAxis.yLabel}
+                    </text>
+                </>
+            )}
 
             {/* Individual Plot Labels */}
             {gridMatrix.map((row, rIdx) => {

--- a/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
+++ b/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
@@ -96,8 +96,8 @@ export const LayoutConfigProvider: React.FC<FieldMapContextProps> = ({ trialId, 
                 setSecondaryAxis({
                     xLabel,
                     yLabel,
-                    xValues: xValues.split(',').map(Number) || [],
-                    yValues: yValues.split(',').map(Number) || []
+                    xValues: (typeof xValues === 'string' ? xValues.split(',') : (Array.isArray(xValues) ? xValues : [])).map(Number).filter(n => !isNaN(n)),
+                    yValues: (typeof yValues === 'string' ? yValues.split(',') : (Array.isArray(yValues) ? yValues : [])).map(Number).filter(n => !isNaN(n))
                 });
             }
         } catch (e) {

--- a/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
+++ b/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { isDefined } from '../../functions';
 import { FieldMapContextProps } from '../types';
@@ -41,6 +41,7 @@ export interface LayoutConfigContextType {
     secondaryAxis: SecondaryAxis | undefined;
     setSecondaryAxis: React.Dispatch<React.SetStateAction<SecondaryAxis | undefined>>;
     loadSecondaryAxis: () => void;
+    hasSecondaryAxis: boolean;
 }
 
 const LayoutConfigContext = createContext<LayoutConfigContextType | undefined>(undefined);
@@ -104,6 +105,14 @@ export const LayoutConfigProvider: React.FC<FieldMapContextProps> = ({ trialId, 
         }
     }, [trialId]);
 
+    const hasSecondaryAxis = useMemo(() => Boolean(
+        secondaryAxis && (
+            secondaryAxis.xLabel || secondaryAxis.yLabel ||
+            (secondaryAxis.xValues && secondaryAxis.xValues.length > 0) ||
+            (secondaryAxis.yValues && secondaryAxis.yValues.length > 0)
+        )
+    ), [secondaryAxis]);
+
     useEffect(() => {
         loadNorthArrowAngle();
         loadSecondaryAxis();
@@ -124,7 +133,8 @@ export const LayoutConfigProvider: React.FC<FieldMapContextProps> = ({ trialId, 
             northArrowAngle, setNorthArrowAngle,
             loadNorthArrowAngle,
             secondaryAxis, setSecondaryAxis,
-            loadSecondaryAxis
+            loadSecondaryAxis,
+            hasSecondaryAxis,
         }}>
             {children}
         </LayoutConfigContext.Provider>

--- a/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
+++ b/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
@@ -88,16 +88,11 @@ export const LayoutConfigProvider: React.FC<FieldMapContextProps> = ({ trialId, 
                     secondary_y_axis_values: yValues
                 } = body;
 
-                if (typeof xValues !== 'string' || typeof yValues !== 'string') {
-                    console.error('Secondary axis values are not strings:', { xValues, yValues });
-                    return;
-                }
-
                 setSecondaryAxis({
                     xLabel,
                     yLabel,
-                    xValues: xValues.split(','),
-                    yValues: yValues.split(','),
+                    xValues: xValues?.split(',') || [],
+                    yValues: yValues?.split(',') || [],
                 });
             }
         } catch (e) {

--- a/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
+++ b/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
@@ -8,10 +8,10 @@ export type ColorVar = 'parity' | 'germplasm' | 'block' | 'family_name' | 'cross
 export type LabelVar = 'plot_number' | 'germplasm' | 'block' | 'family_name' | 'cross_name';
 
 export interface SecondaryAxis {
-    xLabel: string;
-    yLabel: string;
-    xValues: number[];
-    yValues: number[];
+    xLabel?: string;
+    yLabel?: string;
+    xValues?: number[];
+    yValues?: number[];
 }
 
 export interface LayoutConfigContextType {
@@ -87,17 +87,16 @@ export const LayoutConfigProvider: React.FC<FieldMapContextProps> = ({ trialId, 
                     secondary_y_axis_values: yValues
                 } = body;
 
-                if (![xLabel, yLabel, xValues, yValues].every(isDefined)) {
-                    console.warn('Incomplete secondary axis data received, clearing secondary axis state.');
-                    setSecondaryAxis(undefined);
+                if (typeof xValues !== 'string' || typeof yValues !== 'string') {
+                    console.error('Secondary axis values are not strings:', { xValues, yValues });
                     return;
                 }
 
                 setSecondaryAxis({
                     xLabel,
                     yLabel,
-                    xValues: (typeof xValues === 'string' ? xValues.split(',') : (Array.isArray(xValues) ? xValues : [])).map(Number).filter(n => !isNaN(n)),
-                    yValues: (typeof yValues === 'string' ? yValues.split(',') : (Array.isArray(yValues) ? yValues : [])).map(Number).filter(n => !isNaN(n))
+                    xValues: xValues.split(',').map(Number),
+                    yValues: yValues.split(',').map(Number),
                 });
             }
         } catch (e) {

--- a/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
+++ b/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
@@ -1,9 +1,18 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+import { isDefined } from '../../functions';
 import { FieldMapContextProps } from '../types';
 
 export type PlotLayout = 'serpentine' | 'zigzag';
 export type ColorVar = 'parity' | 'germplasm' | 'block' | 'family_name' | 'cross_name';
 export type LabelVar = 'plot_number' | 'germplasm' | 'block' | 'family_name' | 'cross_name';
+
+export interface SecondaryAxis {
+    xLabel: string;
+    yLabel: string;
+    xValues: number[];
+    yValues: number[];
+}
 
 export interface LayoutConfigContextType {
     plotLayout: PlotLayout;
@@ -29,6 +38,9 @@ export interface LayoutConfigContextType {
     northArrowAngle: number;
     setNorthArrowAngle: React.Dispatch<React.SetStateAction<number>>;
     loadNorthArrowAngle: () => void;
+    secondaryAxis: SecondaryAxis | undefined;
+    setSecondaryAxis: React.Dispatch<React.SetStateAction<SecondaryAxis | undefined>>;
+    loadSecondaryAxis: () => void;
 }
 
 const LayoutConfigContext = createContext<LayoutConfigContextType | undefined>(undefined);
@@ -49,6 +61,7 @@ export const LayoutConfigProvider: React.FC<FieldMapContextProps> = ({ trialId, 
     const [labelSize, setLabelSize] = useState(10);
 
     const [northArrowAngle, setNorthArrowAngle] = useState<number>(0);
+    const [secondaryAxis, setSecondaryAxis] = useState<SecondaryAxis | undefined>();
 
     const loadNorthArrowAngle = useCallback(async () => {
         try {
@@ -62,9 +75,40 @@ export const LayoutConfigProvider: React.FC<FieldMapContextProps> = ({ trialId, 
         }
     }, [trialId]);
 
+    const loadSecondaryAxis = useCallback(async () => {
+        try {
+            const response = await fetch(`/ajax/breeders/trial/${trialId}/secondary_axis`);
+            const body = await response.json();
+            if (body) {
+                const {
+                    secondary_x_axis_label: xLabel,
+                    secondary_y_axis_label: yLabel,
+                    secondary_x_axis_values: xValues,
+                    secondary_y_axis_values: yValues
+                } = body;
+
+                if (![xLabel, yLabel, xValues, yValues].every(isDefined)) {
+                    console.warn('Incomplete secondary axis data received, clearing secondary axis state.');
+                    setSecondaryAxis(undefined);
+                    return;
+                }
+
+                setSecondaryAxis({
+                    xLabel,
+                    yLabel,
+                    xValues: xValues.split(',').map(Number) || [],
+                    yValues: yValues.split(',').map(Number) || []
+                });
+            }
+        } catch (e) {
+            console.error('Error loading secondary axis labels and values:', e);
+        }
+    }, [trialId]);
+
     useEffect(() => {
         loadNorthArrowAngle();
-    }, [loadNorthArrowAngle]);
+        loadSecondaryAxis();
+    }, [loadNorthArrowAngle, loadSecondaryAxis]);
 
     return (
         <LayoutConfigContext.Provider value={{
@@ -79,7 +123,9 @@ export const LayoutConfigProvider: React.FC<FieldMapContextProps> = ({ trialId, 
             labelVar, setLabelVar,
             labelSize, setLabelSize,
             northArrowAngle, setNorthArrowAngle,
-            loadNorthArrowAngle
+            loadNorthArrowAngle,
+            secondaryAxis, setSecondaryAxis,
+            loadSecondaryAxis
         }}>
             {children}
         </LayoutConfigContext.Provider>

--- a/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
+++ b/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
@@ -10,8 +10,8 @@ export type LabelVar = 'plot_number' | 'germplasm' | 'block' | 'family_name' | '
 export interface SecondaryAxis {
     xLabel?: string;
     yLabel?: string;
-    xValues?: number[];
-    yValues?: number[];
+    xValues?: string[];
+    yValues?: string[];
 }
 
 export interface LayoutConfigContextType {
@@ -95,8 +95,8 @@ export const LayoutConfigProvider: React.FC<FieldMapContextProps> = ({ trialId, 
                 setSecondaryAxis({
                     xLabel,
                     yLabel,
-                    xValues: xValues.split(',').map(Number),
-                    yValues: yValues.split(',').map(Number),
+                    xValues: xValues.split(','),
+                    yValues: yValues.split(','),
                 });
             }
         } catch (e) {

--- a/js/source/include/fieldmap/contexts/ModalsContext.tsx
+++ b/js/source/include/fieldmap/contexts/ModalsContext.tsx
@@ -17,8 +17,8 @@ export interface ModalsContextType {
 	showDownloadCSVModal: boolean;
 	setShowDownloadCSVModal: React.Dispatch<React.SetStateAction<boolean>>;
 
-    showSecondaryAxisDialog: boolean;
-    setShowSecondaryAxisDialog: React.Dispatch<React.SetStateAction<boolean>>;
+    showSecondaryAxisModal: boolean;
+    setShowSecondaryAxisModal: React.Dispatch<React.SetStateAction<boolean>>;
 
 	loading: boolean;
 	setLoading: React.Dispatch<React.SetStateAction<boolean>>;
@@ -32,7 +32,7 @@ export const ModalsProvider: React.FC<FieldMapContextProps> = ({ children }) => 
     const [showDimDialog, setShowDimDialog] = useState(false);
     const [showDeleteTraitModal, setShowDeleteTraitModal] = useState(false);
     const [showDownloadCSVModal, setShowDownloadCSVModal] = useState(false);
-    const [showSecondaryAxisDialog, setShowSecondaryAxisDialog] = useState(false);
+    const [showSecondaryAxisModal, setShowSecondaryAxisModal] = useState(false);
 
     const [loading, setLoading] = useState(false);
 
@@ -43,7 +43,7 @@ export const ModalsProvider: React.FC<FieldMapContextProps> = ({ children }) => 
             showDimDialog, setShowDimDialog,
             showDeleteTraitModal, setShowDeleteTraitModal,
             showDownloadCSVModal, setShowDownloadCSVModal,
-            showSecondaryAxisDialog, setShowSecondaryAxisDialog,
+            showSecondaryAxisModal, setShowSecondaryAxisModal,
             loading, setLoading,
         }}>
             {children}

--- a/js/source/include/fieldmap/contexts/ModalsContext.tsx
+++ b/js/source/include/fieldmap/contexts/ModalsContext.tsx
@@ -17,6 +17,9 @@ export interface ModalsContextType {
 	showDownloadCSVModal: boolean;
 	setShowDownloadCSVModal: React.Dispatch<React.SetStateAction<boolean>>;
 
+    showSecondaryAxisDialog: boolean;
+    setShowSecondaryAxisDialog: React.Dispatch<React.SetStateAction<boolean>>;
+
 	loading: boolean;
 	setLoading: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -29,6 +32,7 @@ export const ModalsProvider: React.FC<FieldMapContextProps> = ({ children }) => 
     const [showDimDialog, setShowDimDialog] = useState(false);
     const [showDeleteTraitModal, setShowDeleteTraitModal] = useState(false);
     const [showDownloadCSVModal, setShowDownloadCSVModal] = useState(false);
+    const [showSecondaryAxisDialog, setShowSecondaryAxisDialog] = useState(false);
 
     const [loading, setLoading] = useState(false);
 
@@ -39,6 +43,7 @@ export const ModalsProvider: React.FC<FieldMapContextProps> = ({ children }) => 
             showDimDialog, setShowDimDialog,
             showDeleteTraitModal, setShowDeleteTraitModal,
             showDownloadCSVModal, setShowDownloadCSVModal,
+            showSecondaryAxisDialog, setShowSecondaryAxisDialog,
             loading, setLoading,
         }}>
             {children}

--- a/js/source/include/fieldmap/contexts/PlotGridContext.tsx
+++ b/js/source/include/fieldmap/contexts/PlotGridContext.tsx
@@ -61,7 +61,8 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
         setPlotLayout,
         setColorVar,
         setLabelVar,
-        setLabelSize
+        setLabelSize,
+        secondaryAxis
     } = useLayoutConfig();
 
     const {
@@ -176,12 +177,16 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
         };
     }, [bounds, topBorder, bottomBorder, leftBorder, rightBorder]);
 
+    const hasSecondaryAxis = Boolean(secondaryAxis && (secondaryAxis.xLabel || secondaryAxis.yLabel || (secondaryAxis.xValues && secondaryAxis.xValues.length > 0) || (secondaryAxis.yValues && secondaryAxis.yValues.length > 0)));
+
     const svgDimensions = useMemo(() => {
+        const extraWidth = hasSecondaryAxis ? 140 : 50;
+        const extraHeight = hasSecondaryAxis ? 140 : 50;
         return {
-            width: (renderBounds.numCols + 1) * 55 + 50,
-            height: (renderBounds.numRows + 1) * 55 + 50
+            width: (renderBounds.numCols + 1) * 55 + extraWidth,
+            height: (renderBounds.numRows + 1) * 55 + extraHeight
         };
-    }, [renderBounds]);
+    }, [renderBounds, hasSecondaryAxis]);
 
 
     const parsePlotData = useCallback((data: any[]) => {

--- a/js/source/include/fieldmap/contexts/PlotGridContext.tsx
+++ b/js/source/include/fieldmap/contexts/PlotGridContext.tsx
@@ -160,6 +160,9 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
         };
     }, [plotList, dimensions]);
 
+    /**
+     * Computed bounds including borders
+     */
     const renderBounds = useMemo(() => {
         const { minCol, maxCol, minRow, maxRow } = bounds;
         const rMinCol = leftBorder ? minCol - 1 : minCol;

--- a/js/source/include/fieldmap/contexts/PlotGridContext.tsx
+++ b/js/source/include/fieldmap/contexts/PlotGridContext.tsx
@@ -68,7 +68,7 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
         setColorVar,
         setLabelVar,
         setLabelSize,
-        secondaryAxis
+        hasSecondaryAxis
     } = useLayoutConfig();
 
     const {
@@ -189,8 +189,6 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
             numCols: rMaxCol - rMinCol + 1
         };
     }, [bounds, topBorder, bottomBorder, leftBorder, rightBorder]);
-
-    const hasSecondaryAxis = Boolean(secondaryAxis && (secondaryAxis.xLabel || secondaryAxis.yLabel || (secondaryAxis.xValues && secondaryAxis.xValues.length > 0) || (secondaryAxis.yValues && secondaryAxis.yValues.length > 0)));
 
     const svgDimensions = useMemo(() => {
         const extraWidth = hasSecondaryAxis ? 140 : 50;

--- a/js/source/include/fieldmap/contexts/PlotGridContext.tsx
+++ b/js/source/include/fieldmap/contexts/PlotGridContext.tsx
@@ -15,6 +15,11 @@ export interface GridBounds {
     numCols: number;
 }
 
+export interface AxisOrientation {
+    x: { source: 'x' | 'y'; reversed: boolean };
+    y: { source: 'x' | 'y'; reversed: boolean };
+}
+
 export interface PlotGridContextType {
     plotList: Plot[];
     overlappingPlots: Record<string, Plot[]>;
@@ -38,6 +43,7 @@ export interface PlotGridContextType {
     transposeLayout: () => void;
     mapRotation: number;
     rotateLayout: () => void;
+    axisOrientation: AxisOrientation;
 
     plotStructure: PlotStructureNode | null;
     setPlotStructure: React.Dispatch<React.SetStateAction<PlotStructureNode | null>>;
@@ -79,6 +85,10 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
     const [fillerAccessionName, setFillerAccessionName] = useState<string | undefined>(undefined);
     const [isTransposed, setIsTransposed] = useState<boolean>(false);
     const [mapRotation, setMapRotation] = useState<number>(0);
+    const [axisOrientation, setAxisOrientation] = useState<AxisOrientation>({
+        x: { source: 'x', reversed: false },
+        y: { source: 'y', reversed: false }
+    });
 
     const [plotStructure, setPlotStructure] = useState<PlotStructureNode | null>(null);
     const [plotContentCache, setPlotContentCache] = useState<Record<string, string[]>>({});
@@ -195,6 +205,10 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
     const parsePlotData = useCallback((data: any[]) => {
         setIsTransposed(false);
         setMapRotation(0);
+        setAxisOrientation({
+            x: { source: 'x', reversed: false },
+            y: { source: 'y', reversed: false }
+        });
 
         const {
             plotObject,
@@ -246,6 +260,12 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
     }, [bounds, renderBounds, plotList, fillerAccessionId]);
 
     const recalculateLayout = useCallback((layout: 'serpentine' | 'zigzag', rows?: number, cols?: number) => {
+        setIsTransposed(false);
+        setMapRotation(0);
+        setAxisOrientation({
+            x: { source: 'x', reversed: false },
+            y: { source: 'y', reversed: false }
+        });
         setPlotObject(currentPlots => {
             rows = rows ?? dimensions.rows ?? bounds.numRows;
             cols = cols ?? dimensions.cols ?? bounds.numCols;
@@ -298,6 +318,10 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
 
     const transposeLayout = useCallback(() => {
         setIsTransposed(t => !t);
+        setAxisOrientation(prev => ({
+            x: prev.y,
+            y: prev.x
+        }));
         setPlotObject(current => {
             const transposed: Record<string, Plot> = {};
             for (const [id, plot] of Object.entries(current)) {
@@ -317,6 +341,13 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
 
     const rotateLayout = useCallback(() => {
         setMapRotation(r => (r + 90) % 360);
+        setAxisOrientation(prev => ({
+            x: prev.y,
+            y: {
+                source: prev.x.source,
+                reversed: !prev.x.reversed
+            }
+        }));
         const { minCol, maxCol } = bounds;
         setPlotObject(current => {
             const rotated: Record<string, Plot> = {};
@@ -429,6 +460,7 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
             recalculateLayout,
             isTransposed,
             mapRotation,
+            axisOrientation,
             plotStructure,
             setPlotStructure,
             plotContentCache,
@@ -436,7 +468,7 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
             plotImages,
             setPlotImages,
             fetchObservationUnits,
-            applyDimensions
+            applyDimensions,
         }}>
             {children}
         </PlotGridContext.Provider>

--- a/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
+++ b/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
@@ -148,10 +148,10 @@ export const useSubmitFieldLayout = () => {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 			body: buildParams({
-				secondary_x_axis_label: secondaryAxis?.xLabel,
-				secondary_y_axis_label: secondaryAxis?.yLabel,
-				secondary_x_axis_values: secondaryAxis?.xValues?.join(','),
-				secondary_y_axis_values: secondaryAxis?.yValues?.join(',')
+				secondary_x_axis_label: secondaryAxis?.xLabel || '',
+				secondary_y_axis_label: secondaryAxis?.yLabel || '',
+				secondary_x_axis_values: secondaryAxis?.xValues?.join(',') || '',
+				secondary_y_axis_values: secondaryAxis?.yValues?.join(',') || ''
 			})
 		});
 

--- a/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
+++ b/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
@@ -172,8 +172,8 @@ export const useSubmitFieldLayout = () => {
 		trialId, authToken, gridMatrix, invertRows,
 		invertCols, topBorder, leftBorder, rightBorder,
 		bottomBorder, plotLayout, colorVar, labelVar,
-		labelSize, northArrowAngle, fetchObservationUnits,
-		loadNorthArrowAngle, setLoading
+		labelSize, northArrowAngle, secondaryAxis,
+		fetchObservationUnits, loadNorthArrowAngle, loadSecondaryAxis, setLoading
 	]);
 
 	return { submitFieldLayout };

--- a/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
+++ b/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
@@ -3,6 +3,7 @@ import { useLayoutConfig } from '../contexts/LayoutConfigContext';
 import { useModals } from '../contexts/ModalsContext';
 import { usePlotGrid } from '../contexts/PlotGridContext';
 import { useView } from '../contexts/ViewContext';
+import { buildParams, isDefined } from '../../functions';
 
 export const useSubmitFieldLayout = () => {
 	const {
@@ -146,11 +147,11 @@ export const useSubmitFieldLayout = () => {
 		const secondaryAxisRequest = secondaryAxis ? fetch(`/ajax/breeders/trial/${trialId}/secondary_axis`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: new URLSearchParams({
+			body: buildParams({
 				secondary_x_axis_label: secondaryAxis.xLabel,
 				secondary_y_axis_label: secondaryAxis.yLabel,
-				secondary_x_axis_values: secondaryAxis.xValues.join(','),
-				secondary_y_axis_values: secondaryAxis.yValues.join(',')
+				secondary_x_axis_values: secondaryAxis.xValues?.join(','),
+				secondary_y_axis_values: secondaryAxis.yValues?.join(',')
 			})
 		}) : Promise.resolve();
 

--- a/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
+++ b/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
@@ -144,16 +144,16 @@ export const useSubmitFieldLayout = () => {
 			})
 		});
 
-		const secondaryAxisRequest = secondaryAxis ? fetch(`/ajax/breeders/trial/${trialId}/secondary_axis`, {
+		const secondaryAxisRequest = fetch(`/ajax/breeders/trial/${trialId}/secondary_axis`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 			body: buildParams({
-				secondary_x_axis_label: secondaryAxis.xLabel,
-				secondary_y_axis_label: secondaryAxis.yLabel,
-				secondary_x_axis_values: secondaryAxis.xValues?.join(','),
-				secondary_y_axis_values: secondaryAxis.yValues?.join(',')
+				secondary_x_axis_label: secondaryAxis?.xLabel,
+				secondary_y_axis_label: secondaryAxis?.yLabel,
+				secondary_x_axis_values: secondaryAxis?.xValues?.join(','),
+				secondary_y_axis_values: secondaryAxis?.yValues?.join(',')
 			})
-		}) : Promise.resolve();
+		});
 
 		try {
 			await Promise.all([putRequest, postRequest, northArrowRequest, secondaryAxisRequest]);

--- a/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
+++ b/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
@@ -29,7 +29,9 @@ export const useSubmitFieldLayout = () => {
 		labelVar,
 		labelSize,
 		northArrowAngle,
-		loadNorthArrowAngle
+		loadNorthArrowAngle,
+		secondaryAxis,
+		loadSecondaryAxis
 	} = useLayoutConfig();
 
 	const {
@@ -141,13 +143,25 @@ export const useSubmitFieldLayout = () => {
 			})
 		});
 
+		const secondaryAxisRequest = secondaryAxis ? fetch(`/ajax/breeders/trial/${trialId}/secondary_axis`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				secondary_x_axis_label: secondaryAxis.xLabel,
+				secondary_y_axis_label: secondaryAxis.yLabel,
+				secondary_x_axis_values: secondaryAxis.xValues.join(','),
+				secondary_y_axis_values: secondaryAxis.yValues.join(',')
+			})
+		}) : Promise.resolve();
+
 		try {
-			await Promise.all([putRequest, postRequest, northArrowRequest]);
+			await Promise.all([putRequest, postRequest, northArrowRequest, secondaryAxisRequest]);
 			await fetch(`/ajax/breeders/trial/${trialId}/refresh_cache`, { method: 'POST' });
 
 			alert('Field Plot layout submitted successfully!');
 			fetchObservationUnits();
 			loadNorthArrowAngle();
+			loadSecondaryAxis();
 		} catch (e) {
 			console.error('Error submitting layout metadata:', e);
 			alert('Error submitting layout metadata.');

--- a/js/source/include/fieldmap/modals/DimensionsModal.tsx
+++ b/js/source/include/fieldmap/modals/DimensionsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { AccessionAutocomplete } from '../components/AccessionAutocomplete';
 import { useModals } from '../contexts/ModalsContext';
 import { usePlotGrid } from '../contexts/PlotGridContext';
@@ -12,13 +12,20 @@ export const DimensionsModal: React.FC<DimensionsModalProps> = ({}) => {
         setShowDimDialog: setShow,
     } = useModals();
 
+    const {
+        dimensions,
+        applyDimensions,
+        bounds
+    } = usePlotGrid();
+
     const [dimRowsInput, setDimRowsInput] = useState('');
     const [dimColsInput, setDimColsInput] = useState('');
     const [fillerAccessionInput, setFillerAccessionInput] = useState('');
 
-    const {
-        applyDimensions
-    } = usePlotGrid();
+    useEffect(() => {
+        setDimRowsInput((dimensions?.rows || bounds.numRows || '').toString());
+        setDimColsInput((dimensions?.cols || bounds.numCols || '').toString());
+    }, [dimensions, bounds]);
 
     const handleApplyDimensions = async () => {
         await applyDimensions(dimRowsInput, dimColsInput, fillerAccessionInput);

--- a/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
+++ b/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
@@ -7,8 +7,8 @@ interface SecondaryAxisModalProps {
 
 export const SecondaryAxisModal: React.FC<SecondaryAxisModalProps> = ({}) => {
     const {
-        showSecondaryAxisDialog: show,
-        setShowSecondaryAxisDialog: setShow,
+        showSecondaryAxisModal: show,
+        setShowSecondaryAxisModal: setShow,
     } = useModals();
 
     const {

--- a/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
+++ b/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
@@ -15,10 +15,10 @@ export const SecondaryAxisModal: React.FC<SecondaryAxisModalProps> = ({}) => {
         secondaryAxis, setSecondaryAxis,
     } = useLayoutConfig();
 
-    const [secondaryXAxisLabel, setSecondaryXAxisLabel] = useState(secondaryAxis?.xLabel || '');
-    const [secondaryYAxisLabel, setSecondaryYAxisLabel] = useState(secondaryAxis?.yLabel || '');
-    const [secondaryXAxisValues, setSecondaryXAxisValues] = useState(secondaryAxis?.xValues?.join(',') || '');
-    const [secondaryYAxisValues, setSecondaryYAxisValues] = useState(secondaryAxis?.yValues?.join(',') || '');
+    const [secondaryXAxisLabel, setSecondaryXAxisLabel] = useState('');
+    const [secondaryYAxisLabel, setSecondaryYAxisLabel] = useState('');
+    const [secondaryXAxisValues, setSecondaryXAxisValues] = useState('');
+    const [secondaryYAxisValues, setSecondaryYAxisValues] = useState('');
 
     useEffect(() => {
         if (show) {

--- a/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
+++ b/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useModals } from '../contexts/ModalsContext';
 import { useLayoutConfig } from '../contexts/LayoutConfigContext';
 
@@ -17,16 +17,31 @@ export const SecondaryAxisModal: React.FC<SecondaryAxisModalProps> = ({}) => {
 
     const [secondaryXAxisLabel, setSecondaryXAxisLabel] = useState(secondaryAxis?.xLabel || '');
     const [secondaryYAxisLabel, setSecondaryYAxisLabel] = useState(secondaryAxis?.yLabel || '');
-    const [secondaryXAxisValues, setSecondaryXAxisValues] = useState(secondaryAxis?.xValues.join(',') || '');
-    const [secondaryYAxisValues, setSecondaryYAxisValues] = useState(secondaryAxis?.yValues.join(',') || '');
+    const [secondaryXAxisValues, setSecondaryXAxisValues] = useState(secondaryAxis?.xValues?.join(',') || '');
+    const [secondaryYAxisValues, setSecondaryYAxisValues] = useState(secondaryAxis?.yValues?.join(',') || '');
+
+    useEffect(() => {
+        if (show) {
+            setSecondaryXAxisLabel(secondaryAxis?.xLabel || '');
+            setSecondaryYAxisLabel(secondaryAxis?.yLabel || '');
+            setSecondaryXAxisValues(secondaryAxis?.xValues?.join(',') || '');
+            setSecondaryYAxisValues(secondaryAxis?.yValues?.join(',') || '');
+        }
+    }, [show, secondaryAxis]);
 
     const handleApplyDimensions = async () => {
-        setSecondaryAxis({
-            xLabel: secondaryXAxisLabel,
-            yLabel: secondaryYAxisLabel,
-            xValues: secondaryXAxisValues.split(',').map(Number),
-            yValues: secondaryYAxisValues.split(',').map(Number)
-        });
+        const xVals = secondaryXAxisValues.trim() ? secondaryXAxisValues.split(',').map(v => Number(v.trim())).filter(v => !isNaN(v)) : [];
+        const yVals = secondaryYAxisValues.trim() ? secondaryYAxisValues.split(',').map(v => Number(v.trim())).filter(v => !isNaN(v)) : [];
+        if (secondaryXAxisLabel || secondaryYAxisLabel || xVals.length > 0 || yVals.length > 0) {
+            setSecondaryAxis({
+                xLabel: secondaryXAxisLabel,
+                yLabel: secondaryYAxisLabel,
+                xValues: xVals,
+                yValues: yVals
+            });
+        } else {
+            setSecondaryAxis(undefined);
+        }
         setShow(false);
     };
 

--- a/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
+++ b/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
@@ -31,8 +31,7 @@ export const SecondaryAxisModal: React.FC<SecondaryAxisModalProps> = ({}) => {
 
     const handleApply = async () => {
         const toValueArray = (str: string) => str.split(',')
-            .map(v => v.trim())
-            .filter(v => v !== '');
+            .map(v => v.trim());
 
         const xValues = toValueArray(secondaryXAxisValues);
         const yValues = toValueArray(secondaryYAxisValues);

--- a/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
+++ b/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { useModals } from '../contexts/ModalsContext';
+import { useLayoutConfig } from '../contexts/LayoutConfigContext';
+
+interface SecondaryAxisModalProps {
+}
+
+export const SecondaryAxisModal: React.FC<SecondaryAxisModalProps> = ({}) => {
+    const {
+        showSecondaryAxisDialog: show,
+        setShowSecondaryAxisDialog: setShow,
+    } = useModals();
+
+    const {
+        secondaryAxis, setSecondaryAxis,
+    } = useLayoutConfig();
+
+    const [secondaryXAxisLabel, setSecondaryXAxisLabel] = useState(secondaryAxis?.xLabel || '');
+    const [secondaryYAxisLabel, setSecondaryYAxisLabel] = useState(secondaryAxis?.yLabel || '');
+    const [secondaryXAxisValues, setSecondaryXAxisValues] = useState(secondaryAxis?.xValues.join(',') || '');
+    const [secondaryYAxisValues, setSecondaryYAxisValues] = useState(secondaryAxis?.yValues.join(',') || '');
+
+    const handleApplyDimensions = async () => {
+        setSecondaryAxis({
+            xLabel: secondaryXAxisLabel,
+            yLabel: secondaryYAxisLabel,
+            xValues: secondaryXAxisValues.split(',').map(Number),
+            yValues: secondaryYAxisValues.split(',').map(Number)
+        });
+        setShow(false);
+    };
+
+    if (!show) return null;
+
+    return (
+        <div className="modal show tw:block tw:bg-black/50">
+            <div className="modal-dialog">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        <button type="button" className="close" onClick={() => setShow(false)}>&times;</button>
+                        <h4 className="modal-title">Change Secondary Axis</h4>
+                    </div>
+                    <div className="modal-body">
+                        <div className="form-group">
+                            <label>Secondary X Axis Label:</label>
+                            <input type="text" className="form-control" value={secondaryXAxisLabel} onChange={e => setSecondaryXAxisLabel(e.target.value)} />
+                        </div>
+                        <div className="form-group">
+                            <label>Secondary X Axis Values (comma-separated):</label>
+                            <input type="text" className="form-control" value={secondaryXAxisValues} onChange={e => setSecondaryXAxisValues(e.target.value)} />
+                        </div>
+                        <div className="form-group">
+                            <label>Secondary Y Axis Label:</label>
+                            <input type="text" className="form-control" value={secondaryYAxisLabel} onChange={e => setSecondaryYAxisLabel(e.target.value)} />
+                        </div>
+                        <div className="form-group">
+                            <label>Secondary Y Axis Values (comma-separated):</label>
+                            <input type="text" className="form-control" value={secondaryYAxisValues} onChange={e => setSecondaryYAxisValues(e.target.value)} />
+                        </div>
+                    </div>
+                    <div className="modal-footer">
+                        <button className="btn btn-default" onClick={() => setShow(false)}>Cancel</button>
+                        <button className="btn btn-primary" onClick={handleApplyDimensions}>Apply</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
+++ b/js/source/include/fieldmap/modals/SecondaryAxisModal.tsx
@@ -29,15 +29,20 @@ export const SecondaryAxisModal: React.FC<SecondaryAxisModalProps> = ({}) => {
         }
     }, [show, secondaryAxis]);
 
-    const handleApplyDimensions = async () => {
-        const xVals = secondaryXAxisValues.trim() ? secondaryXAxisValues.split(',').map(v => Number(v.trim())).filter(v => !isNaN(v)) : [];
-        const yVals = secondaryYAxisValues.trim() ? secondaryYAxisValues.split(',').map(v => Number(v.trim())).filter(v => !isNaN(v)) : [];
-        if (secondaryXAxisLabel || secondaryYAxisLabel || xVals.length > 0 || yVals.length > 0) {
+    const handleApply = async () => {
+        const toValueArray = (str: string) => str.split(',')
+            .map(v => v.trim())
+            .filter(v => v !== '');
+
+        const xValues = toValueArray(secondaryXAxisValues);
+        const yValues = toValueArray(secondaryYAxisValues);
+
+        if (secondaryXAxisLabel || secondaryYAxisLabel || xValues.length > 0 || yValues.length > 0) {
             setSecondaryAxis({
                 xLabel: secondaryXAxisLabel,
                 yLabel: secondaryYAxisLabel,
-                xValues: xVals,
-                yValues: yVals
+                xValues,
+                yValues
             });
         } else {
             setSecondaryAxis(undefined);
@@ -75,7 +80,7 @@ export const SecondaryAxisModal: React.FC<SecondaryAxisModalProps> = ({}) => {
                     </div>
                     <div className="modal-footer">
                         <button className="btn btn-default" onClick={() => setShow(false)}>Cancel</button>
-                        <button className="btn btn-primary" onClick={handleApplyDimensions}>Apply</button>
+                        <button className="btn btn-primary" onClick={handleApply}>Apply</button>
                     </div>
                 </div>
             </div>

--- a/js/source/include/functions.ts
+++ b/js/source/include/functions.ts
@@ -1,3 +1,23 @@
+/**
+ * Checks if a value is defined (not undefined or null).
+ * @param value - The value to check for definition.
+ * @returns True if the value is neither undefined nor null, otherwise false.
+ */
 export const isDefined = <T>(value: T | undefined | null): value is T => {
 	return value !== undefined && value !== null;
-}
+};
+
+/**
+ * Converts an object of key-value pairs into URL search parameters.
+ * @param mappings - An object containing key-value pairs to be converted into URL search parameters.
+ * @returns A URLSearchParams object containing the provided mappings.
+ */
+export const buildParams = (mappings: Record<string, any>) => {
+	const params = new URLSearchParams();
+	for (const [key, value] of Object.entries(mappings)) {
+		if (isDefined(value)) {
+			params.append(key, String(value));
+		}
+	}
+	return params;
+};

--- a/js/source/include/functions.ts
+++ b/js/source/include/functions.ts
@@ -1,0 +1,3 @@
+export const isDefined = <T>(value: T | undefined | null): value is T => {
+	return value !== undefined && value !== null;
+}

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -6782,4 +6782,86 @@ sub north_arrow_angle_POST {
     $c->stash->{rest} = { success => 1 };
 }
 
+sub secondary_axis : Chained('trial') PathPart('secondary_axis') Args(0) ActionClass('REST') {};
+
+sub secondary_axis_GET {
+    my $self = shift;
+    my $c = shift;
+    my $schema = $c->stash->{schema};
+    my $trial_id = $c->stash->{trial_id};
+
+    my $read_prop = sub {
+        my ($cvterm_name) = @_;
+        my $cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, $cvterm_name, 'project_property');
+        if (!$cvterm) {
+            $c->stash->{rest} = { error => "Cvterm '$cvterm_name' not found. Has the db patch been run?" };
+            return;
+        }
+        my $prop = $schema->resultset("Project::Projectprop")->find({
+            project_id => $trial_id,
+            type_id => $cvterm->cvterm_id()
+        });
+        return $prop ? $prop->value() : undef;
+    };
+
+    $c->stash->{rest} = {
+        secondary_x_axis_label => $read_prop->('secondary_x_axis_label'),
+        secondary_y_axis_label => $read_prop->('secondary_y_axis_label'),
+        secondary_x_axis_values => $read_prop->('secondary_x_axis_values'),
+        secondary_y_axis_values => $read_prop->('secondary_y_axis_values'),
+    };
+}
+
+sub secondary_axis_POST {
+    my $self = shift;
+    my $c = shift;
+
+    if ($self->privileges_denied($c)) {
+        $c->stash->{rest} = { error => "You have insufficient access privileges to edit this trial." };
+        return;
+    }
+
+    my $schema = $c->stash->{schema};
+    my $trial_id = $c->stash->{trial_id};
+
+    my %props_to_set = (
+        secondary_x_axis_label => $c->req->param('secondary_x_axis_label'),
+        secondary_y_axis_label => $c->req->param('secondary_y_axis_label'),
+        secondary_x_axis_values => $c->req->param('secondary_x_axis_values'),
+        secondary_y_axis_values => $c->req->param('secondary_y_axis_values'),
+    );
+
+    foreach my $cvterm_name (keys %props_to_set) {
+        my $value = $props_to_set{$cvterm_name};
+        my $cvterm = SGN::Model::Cvterm->get_cvterm_row($schema, $cvterm_name, 'project_property');
+        if (!$cvterm) {
+            $c->stash->{rest} = { error => "Cvterm '$cvterm_name' not found. Has the db patch been run?" };
+            return;
+        }
+        my $prop = $schema->resultset("Project::Projectprop")->find({
+            project_id => $trial_id,
+            type_id => $cvterm->cvterm_id()
+        });
+
+        if (defined $value && $value ne '') {
+            if ($prop) {
+                $prop->update({ value => $value });
+            } else {
+                $schema->resultset("Project::Projectprop")->create({
+                    project_id => $trial_id,
+                    type_id => $cvterm->cvterm_id(),
+                    value => $value,
+                    rank => 0
+                });
+            }
+        } else {
+            if ($prop) {
+                $prop->delete();
+            }
+        }
+    }
+
+    $c->stash->{rest} = { success => 1 };
+
+}
 1;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR adds configurable secondary axes to the fieldmap.

**Backend**
- Created a migration to add `secondary_x_axis_label`, `secondary_y_axis_label`, `secondary_x_axis_values`, `secondary_y_axis_values` project props
- Added `secondary_axis_GET` and `secondary_axis_POST` request handlers to `TrialMetadata.pm` to get/set the axis configuration

**Frontend**
- Added axis loading to `LayoutConfigContext.tsx`
- Updated `submitFieldLayout` to save the secondary axis configuration in a concurrent request
- Added a new modal `SecondaryAxisModal.tsx` for configuring the secondary axes
- Added a new button to the toolbar that opens the configuration modal
- Replaced the labels of all toolbar buttons other than the "Submit Layout Changes" button with icons
   - The full label text still appears in a tooltip when hovering over a button

**Tests**
- No tests were created for this functionality. Since the fieldmap as a whole is in need of testing, I created a separate issue #253 to track this.

**Notes**
- Values are persisted as a string of comma-separated values
   - The frontend handles the serialization in and out of this format, while the backend works with the complete string without inspecting its contents
- No restrictions are placed on the formatting of axis values: alphabet, numeral, and symbol characters are all supported
- The secondary axes rotate/reflect/transpose with the configured layout, however the primary axes _do not_
   - This is existing behaviour that I have not modified in this PR

**All axes configured:**
<img width="756" height="471" alt="image" src="https://github.com/user-attachments/assets/682e99b5-4420-4c30-b18c-ed43c644bb0d" />

**Toolbar button:**
<img width="582" height="220" alt="image" src="https://github.com/user-attachments/assets/6260dd14-a0ff-4dd7-bbe8-6fff28a5b918" />

**Configuration modal:**
<img width="627" height="358" alt="image" src="https://github.com/user-attachments/assets/22743cba-ef4e-4b1c-a13c-927c5f8605b6" />


---

- Closes #161 
<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
