### PR TITLE
fix(genotype): Fix genotyping views

### DIFF
--- a/db/00207/FixGenotypingViews.pm
+++ b/db/00207/FixGenotypingViews.pm
@@ -352,7 +352,7 @@ create view public.genotyping_projectsxsubplots as (
     join stock_relationship on ( stock_id = subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id )
     join stock as subplot on ( object_id = subplot.stock_id and subplot.type_id = $subplot_cvterm_id )
 );
-alter view public.genotyping_projectsxplots owner to web_usr;
+alter view public.genotyping_projectsxsubplots owner to web_usr;
 
 
 -------------------------------------------------------------------------------

--- a/db/00207/FixGenotypingViews.pm
+++ b/db/00207/FixGenotypingViews.pm
@@ -1,0 +1,896 @@
+#!/usr/bin/env perl
+
+=head1 NAME
+
+FixGenotypingViews.pm
+
+=head1 SYNOPSIS
+
+mx-run FixGenotypingViews [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+This patch fixes genotyping views including genotyping_protocols and genotyping_projects.
+
+=head1 AUTHOR
+
+Katherine Eaton <kmeaton1@ualberta.ca>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2026 University of Alberta
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+package FixGenotypingViews;
+
+use SGN::Model::Cvterm;
+use Bio::Chado::Schema;
+use Moose;
+extends 'CXGN::Metadata::Dbpatch';
+
+has '+description' => ( default => 'Fixes genotyping views including genotyping_protocols and genotyping_projects.' );
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " . $self->name . ".\n\nDescription:\n  " . $self->description . ".\n\nExecuted by:\n " . $self->username . " .";
+
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+
+    print STDOUT "\nFetching Cvterms.\n";
+    my $schema = Bio::Chado::Schema->connect( sub { $self->dbh->clone } );
+
+    my $accession_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'accession', 'stock_type')->cvterm_id();
+    my $breeding_program_trial_relationship_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'breeding_program_trial_relationship', 'project_relationship')->cvterm_id();
+    my $genotyping_experiment_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'genotyping_experiment', 'experiment_type')->cvterm_id();
+    my $plant_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant', 'stock_type')->cvterm_id();
+    my $plot_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plot', 'stock_type')->cvterm_id();
+    my $project_year_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'project year', 'project_property')->cvterm_id();
+    my $subplot_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'subplot', 'stock_type')->cvterm_id();
+    my $project_location_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'project location', 'project_property')->cvterm_id();
+    my $seed_transaction_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'seed transaction', 'stock_relationship')->cvterm_id();
+    my $tissue_sample_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample', 'stock_type')->cvterm_id();
+    my $tissue_sample_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample_of', 'stock_relationship')->cvterm_id();
+    my $trial_design_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'design', 'project_property')->cvterm_id();
+
+    my $project_type_cv_id = $schema->resultset("Cv::Cv")->find({ name => 'project_type'})->cv_id();
+
+    # Views that will be updated:
+    #  - accessionsxgenotyping_projects
+    #  - accessionsxgenotyping_protocols
+    #  - breeding_programsxgenotyping_projects
+    #  - breeding_programsxgenotyping_protocols
+    #  - genotyping_projects
+    #  - genotyping_projectsxgenotyping_protocols
+    #  - genotyping_projectsxlocations
+    #  - genotyping_projectsxorganisms
+    #  - genotyping_projectsxplants
+    #  - genotyping_projectsxplots
+    #  - genotyping_projectsxseedlots
+    #  - genotyping_projectsxsubplots
+    #  - genotyping_projectsxtissue_sample
+    #  - genotyping_projectsxtrait_components
+    #  - genotyping_projectsxtraits
+    #  - genotyping_projectsxtrial_designs
+    #  - genotyping_projectsxtrial_types
+    #  - genotyping_projectsxtrials
+    #  - genotyping_projectsxyears
+    #  - genotyping_protocols
+    #  - genotyping_protocolsxlocations
+    #  - genotyping_protocolsxorganisms
+    #  - genotyping_protocolsxplants
+    #  - genotyping_protocolsxplots
+    #  - genotyping_protocolsxseedlots
+    #  - genotyping_protocolsxsubplots
+    #  - genotyping_protocolsxtissue_sample
+    #  - genotyping_protocolsxtrait_components
+    #  - genotyping_protocolsxtraits
+    #  - genotyping_protocolsxtrial_designs
+    #  - genotyping_protocolsxtrial_types
+    #  - genotyping_protocolsxtrials
+    #  - genotyping_protocolsxyears
+
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    $self->dbh->do(<<EOSQL);
+-------------------------------------------------------------------------------
+-- View: accessionsxgenotyping_projects
+-- Objective: Link genotyping projects to the accessions that have been
+--            genotyped. There are two stock types that can be genotyped:
+--            accessions and tissue samples. In the case of tissue samples,
+--            we report the parent accession in this view.
+-- Reason For Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples and accessions.
+--   2. Get parent accessions of tissue samples.
+
+drop view public.accessionsxgenotyping_projects;
+create view public.accessionsxgenotyping_projects as (
+    select
+        distinct
+            coalesce(accession_of_tissue_sample.stock_id, accession.stock_id) as accession_id,
+            project_id as genotyping_project_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    left join stock_relationship on (stock_id = stock_relationship.subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id )
+    left join stock as tissue_sample on ( subject_id = tissue_sample.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id )
+    left join stock as accession_of_tissue_sample on ( object_id = accession_of_tissue_sample.stock_id and accession_of_tissue_sample.type_id = $accession_cvterm_id )
+    left join stock as accession on ( nd_experiment_stock.stock_id = accession.stock_id and accession.type_id = $accession_cvterm_id )
+    where coalesce(accession_of_tissue_sample.uniquename, accession.uniquename) is not null
+);
+alter view public.accessionsxgenotyping_projects owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: accessionsxgenotyping_protocols
+-- Objective: Link genotyping protocols to the accessions that have been
+--            genotyped. There are two stock types that can be genotyped:
+--            accessions and tissue samples. In the case of tissue samples,
+--            we report the parent accession in this view.
+-- Reason For Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples and accessions.
+--   2. Get parent accessions of tissue samples.
+
+drop view public.accessionsxgenotyping_protocols;
+create view public.accessionsxgenotyping_protocols as (
+    select
+        distinct
+            coalesce(accession_of_tissue_sample.stock_id, accession.stock_id) as accession_id,
+            nd_protocol_id as genotyping_protocol_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    left join stock_relationship on (stock_id = stock_relationship.subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id )
+    left join stock as tissue_sample on ( subject_id = tissue_sample.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id )
+    left join stock as accession_of_tissue_sample on ( object_id = accession_of_tissue_sample.stock_id and accession_of_tissue_sample.type_id = $accession_cvterm_id )
+    left join stock as accession on ( nd_experiment_stock.stock_id = accession.stock_id and accession.type_id = $accession_cvterm_id )
+    where coalesce(accession_of_tissue_sample.uniquename, accession.uniquename) is not null
+);
+alter view public.accessionsxgenotyping_protocols owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: breeding_programsxgenotyping_projects
+-- Objective: Link genotyping projects to the breeding program
+--            they were performed in.
+-- Reason For Change: Avoid use of subqueries.
+-- Steps:
+--   1. Get genotyping projects.
+--   2. Get breeding program the project is associated with.
+
+drop view public.breeding_programsxgenotyping_projects;
+create view public.breeding_programsxgenotyping_projects as (
+    select distinct object_project_id as breeding_program_id, project_id as genotyping_project_id
+    from project_relationship
+    join cvterm on (type_id = cvterm_id and cvterm_id = $breeding_program_trial_relationship_cvterm_id)
+    join projectprop on (subject_project_id = projectprop.project_id and projectprop.value = 'genotype_data_project' and projectprop.type_id = $trial_design_cvterm_id)
+    join nd_experiment_project using (project_id)
+);
+alter view public.breeding_programsxgenotyping_projects owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: breeding_programsxgenotyping_protocols
+-- Objective: Link genotyping protocols to the breeding program
+--            they were performed in.
+-- Reason For Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyping projects.
+--   2. Get breeding program the project is associated with.
+
+drop view public.breeding_programsxgenotyping_protocols;
+create view public.breeding_programsxgenotyping_protocols as (
+    select distinct object_project_id as breeding_program_id, nd_protocol_id as genotyping_protocol_id
+    from project_relationship
+    join cvterm on (type_id = cvterm_id and cvterm_id = $breeding_program_trial_relationship_cvterm_id)
+    join projectprop on (subject_project_id = projectprop.project_id and projectprop.value = 'genotype_data_project' and projectprop.type_id = $trial_design_cvterm_id)
+    join nd_experiment_project using (project_id)
+    join nd_experiment_protocol using (nd_experiment_id)
+);
+alter view public.breeding_programsxgenotyping_protocols owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxgenotyping_protocols
+-- Objective: Link genotyping protocols to the genotyping
+--            projects they have been used in.
+-- Reason For Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyping protocols.
+--   2. Get parent genotyping projects.
+
+drop view public.genotyping_projectsxgenotyping_protocols;
+create view public.genotyping_projectsxgenotyping_protocols as (
+    select distinct project.project_id as genotyping_project_id, nd_protocol_id as genotyping_protocol_id
+    from nd_experiment_protocol
+    join nd_experiment_project using (nd_experiment_id)
+    join project using (project_id)
+    join projectprop on ( projectprop.project_id = project.project_id and projectprop.type_id = $trial_design_cvterm_id and value = 'genotype_data_project' )
+);
+alter view public.genotyping_projectsxgenotyping_protocols owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxlocations
+-- Objective: Link genotyping protocols to the locations
+--            of the genotyping material, according to
+--            where the trial of the parent plot is.
+-- Reason For Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get parent plots of tissue samples.
+--   3. Get trial plot is in.
+--   4. Get location where trial is.
+
+
+drop view public.genotyping_projectsxlocations;
+create view public.genotyping_projectsxlocations as (
+    select distinct nd_experiment_project.project_id as genotyping_project_id, (projectprop.value)::integer as location_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id )
+    join stock as plot on ( plot.stock_id = object_id and plot.type_id = $plot_cvterm_id )
+    join nd_experiment_stock as nd_experiment_plot on (plot.stock_id = nd_experiment_plot.stock_id)
+    join nd_experiment_project as plot_trial on (nd_experiment_plot.nd_experiment_id = plot_trial.nd_experiment_id)
+    join projectprop on ( plot_trial.project_id = projectprop.project_id and projectprop.type_id = $project_location_cvterm_id )
+);
+alter view public.genotyping_projectsxlocations owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxorganisms
+-- Objective: Link genotyping projects to organisms of genotyped material.
+-- Reason For Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples and accessions.
+--   2. Get organisms of genotyped stocks.
+
+drop view public.genotyping_projectsxorganisms;
+create view public.genotyping_projectsxorganisms as (
+    select distinct project_id as genotyping_project_id, coalesce(tissue_sample.organism_id, accession.organism_id) as organism_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    left join stock_relationship on ( stock_id = stock_relationship.subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id )
+    left join stock as tissue_sample on ( object_id = tissue_sample.stock_id and tissue_sample.type_id = $accession_cvterm_id )
+    left join stock as accession on ( nd_experiment_stock.stock_id = accession.stock_id and accession.type_id = $accession_cvterm_id )
+    where coalesce(tissue_sample.organism_id, accession.organism_id) is not null
+);
+alter view public.genotyping_projectsxorganisms owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxplants
+-- Objective: Link genotyping projects to plants who have genotyped tissue samples.
+-- Reason For Change: Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get parent plants of tissue samples.
+
+drop view public.genotyping_projectsxplants;
+create view public.genotyping_projectsxplants as (
+    select distinct project_id as genotyping_project_id, plant.stock_id as plant_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on (stock_id = subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id)
+    join stock as plant on (object_id = plant.stock_id and plant.type_id = $plant_cvterm_id)
+);
+alter view public.genotyping_projectsxplants owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxplots
+-- Objective: Link genotyping projects to plots that contain genotyped tissue samples.
+-- Reason for Change: Pre-existing view gave wrong results, plots that were not genotyped.
+--                    Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get parent plots of tissue samples.
+--   3. Get genotyping project tissue sample was used in.
+
+drop view public.genotyping_projectsxplots;
+create view public.genotyping_projectsxplots as (
+    select distinct project_id as genotyping_project_id, plot.stock_id as plot_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id )
+    join stock as plot on ( object_id = plot.stock_id and plot.type_id = $plot_cvterm_id )
+);
+alter view public.genotyping_projectsxplots owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxseedlots
+-- Objective: Link genotyping protocols to tissue samples that are in plots with known seeds.
+-- Reason for Change: Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get parent plots.
+--   3. Get seedlots planted in plots.
+
+drop view public.genotyping_projectsxseedlots;
+create view public.genotyping_projectsxseedlots as (
+    select distinct project_id as genotyping_project_id, seedlot_of_plot.object_id as seedlot_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id )
+    join stock as plot on ( plot.stock_id = object_id and plot.type_id = $plot_cvterm_id )
+    join stock_relationship as seedlot_of_plot on (plot.stock_id = seedlot_of_plot.subject_id and seedlot_of_plot.type_id = $seed_transaction_cvterm_id)
+);
+alter view public.genotyping_projectsxseedlots owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxsubplots
+-- Objective: Link genotyping projects to subplots that contain genotyped tissue samples.
+-- Reason for Change: Pre-existing view gave wrong results, subplots that were not genotyped.
+--                    Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get parent subplots of tissue samples.
+--   3. Get genotyping project tissue sample was used in.
+
+drop view public.genotyping_projectsxsubplots;
+create view public.genotyping_projectsxsubplots as (
+    select distinct project_id as genotyping_project_id, subplot.stock_id as plot_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id )
+    join stock as subplot on ( object_id = subplot.stock_id and subplot.type_id = $subplot_cvterm_id )
+);
+alter view public.genotyping_projectsxplots owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxtissue_sample
+-- Objective: Link genotyping projects to plots that contain genotyped tissue samples.
+-- Reason for Change: Pre-existing view did not exist.
+-- Reminder: Table name is non-pluralized (tissue_sample) for legacy support
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   3. Get genotyping project tissue sample was used in.
+
+create view public.genotyping_projectsxtissue_sample as (
+    select distinct project_id as genotyping_project_id, stock_relationship.subject_id as tissue_sample_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id )
+);
+alter view public.genotyping_projectsxtissue_sample owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxtraits
+-- Objective: Link genotyping projects to tissue samples that have been phenotyped.
+--            The tissue sample may be genotyped or any of its parents (plant, plot, etc.)
+-- Reason for Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Also get parents of genotyped tissue samples.
+--   3. Get phenotypes of both tissue samples or parents.
+-- Note: I would prefer this view did not utilize a subquery.
+
+drop view public.genotyping_projectsxtraits;
+create view public.genotyping_projectsxtraits as (
+    select distinct genotyping_project_id, observable_id as trait_id from (
+        select
+            unnest(array_cat(array_agg(project_id),array_agg(project_id))) as genotyping_project_id,
+            unnest(array_cat(array_agg(tissue_sample.stock_id), array_agg(parent.stock_id))) as stock_id
+            from nd_experiment_genotype
+            join nd_experiment_project using (nd_experiment_id)
+            join nd_experiment_stock using (nd_experiment_id)
+            join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id )
+            join stock_relationship on (tissue_sample.stock_id = subject_id)
+            join stock as parent on (object_id = parent.stock_id)
+    )
+    join nd_experiment_stock using (stock_id)
+    join nd_experiment_phenotype using (nd_experiment_id)
+    join phenotype using (phenotype_id)
+);
+alter view public.genotyping_projectsxtraits owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxtrait_components
+-- Objective: Link genotyping projects to stocks phenotyped using composed traits.
+--            The tissue sample may be genotyped or any of its parents (plant, plot, etc.)
+-- Reason for Change: Pre-existing view incorrectly returned no results.
+--                    Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Also get parents of genotyped tissue samples.
+--   3. Get phenotypes of both tissue samples or parents.
+--   4. Get trait components of phenotypes.
+-- Note: I would prefer this view did not utilize a subquery.
+
+drop view public.genotyping_projectsxtrait_components;
+create view public.genotyping_projectsxtrait_components as (
+    select distinct genotyping_project_id, cvterm_relationship.subject_id as trait_component_id from (
+        select
+            unnest(array_cat(array_agg(project_id),array_agg(project_id))) as genotyping_project_id,
+            unnest(array_cat(array_agg(tissue_sample.stock_id), array_agg(parent.stock_id))) as stock_id
+            from nd_experiment_genotype
+            join nd_experiment_project using (nd_experiment_id)
+            join nd_experiment_stock using (nd_experiment_id)
+            join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+            join stock_relationship on (tissue_sample.stock_id = subject_id)
+            join stock as parent on (object_id = parent.stock_id)
+    )
+    join nd_experiment_stock using (stock_id)
+    join nd_experiment_phenotype using (nd_experiment_id)
+    join phenotype using (phenotype_id)
+    join cvterm_relationship on (object_id = observable_id)
+);
+alter view public.genotyping_projectsxtrait_components owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: public.genotyping_projectsxtrial_designs
+-- Objective: Link genotyping protocols to tissue samples that are found in trials
+--            according to trial design.
+-- Reason for Change: Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get plots of those tissue samples.
+--   3. Get trials the plots are in.
+--   4. Get design of the trial.
+
+drop view public.genotyping_projectsxtrial_designs;
+create view public.genotyping_projectsxtrial_designs as (
+    select distinct nd_experiment_project.project_id as genotyping_project_id, projectprop.value as trial_design_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( nd_experiment_stock.stock_id = stock_relationship.subject_id )
+    join stock as plot on ( plot.stock_id = object_id and plot.type_id = $plot_cvterm_id)
+    join nd_experiment_stock as nd_experiment_plot on (plot.stock_id = nd_experiment_plot.stock_id)
+    join nd_experiment_project as plot_trial on (nd_experiment_plot.nd_experiment_id = plot_trial.nd_experiment_id)
+    join projectprop on ( plot_trial.project_id = projectprop.project_id and projectprop.type_id = $trial_design_cvterm_id )
+);
+alter view public.genotyping_projectsxtrial_designs owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: public.genotyping_projectsxtrial_types
+-- Objective: Link genotyping projects to tissue samples that are found in trials
+--            according to trial type.
+-- Reason for Change: Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get plots of those tissue samples.
+--   3. Get trials the plots are in.
+--   4. Get type of the trial.
+
+drop view public.genotyping_projectsxtrial_types;
+create view public.genotyping_projectsxtrial_types as (
+    select distinct nd_experiment_project.project_id as genotyping_project_id, projectprop.type_id as trial_type_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( nd_experiment_stock.stock_id = stock_relationship.subject_id )
+    join stock as plot on ( plot.stock_id = object_id and plot.type_id = $plot_cvterm_id )
+    join nd_experiment_stock as nd_experiment_plot on (plot.stock_id = nd_experiment_plot.stock_id)
+    join nd_experiment_project as plot_trial on (nd_experiment_plot.nd_experiment_id = plot_trial.nd_experiment_id)
+    join projectprop on (projectprop.project_id = plot_trial.project_id)
+    join cvterm on (projectprop.type_id = cvterm.cvterm_id and cvterm.cv_id = $project_type_cv_id)
+);
+alter view public.genotyping_projectsxtrial_types owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: public.genotyping_projectsxtrials
+-- Objective: Link genotyping projects to tissue samples that are found in trials.
+-- Reason for Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get plots of those tissue samples.
+--   3. Get trials the plots are in.
+
+drop view public.genotyping_projectsxtrials;
+create view public.genotyping_projectsxtrials as (
+    select distinct nd_experiment_project.project_id as genotyping_project_id, plot_trial.project_id as trial_id
+    from nd_experiment_genotype
+    join nd_experiment_project using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id )
+    join stock as plot on ( plot.stock_id = object_id and plot.type_id = $plot_cvterm_id )
+    join nd_experiment_stock as nd_experiment_plot on (plot.stock_id = nd_experiment_plot.stock_id)
+    join nd_experiment_project as plot_trial on (nd_experiment_plot.nd_experiment_id = plot_trial.nd_experiment_id)
+);
+alter view public.genotyping_projectsxtrials owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projects
+-- Objective: Get all genotyping projects.
+-- Reason for Change: Avoid use of subqueries.
+-- Steps:
+--  1. Get all projects that are genotyping data projects.
+
+drop view public.genotyping_projects;
+create view public.genotyping_projects as (
+    select distinct project.project_id as genotyping_project_id, project.name as genotyping_project_name
+    from project
+    join projectprop on (projectprop.project_id = project.project_id and value = 'genotype_data_project' and projectprop.type_id = $trial_design_cvterm_id)
+);
+alter view public.genotyping_projects owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_projectsxyears
+-- Objective: Link genotyping projects to tissue samples that are found in trials
+--            according to genotyping project year.
+-- Reason for Change: Avoid use of subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   3. Get genotyping project the tissue samples are in.
+--   4. Get year of the genotyping data project.
+
+
+drop view public.genotyping_projectsxyears;
+create view public.genotyping_projectsxyears as (
+    select distinct project.project_id as genotyping_project_id, year.value as year_id
+    from project
+    join projectprop on (projectprop.project_id = project.project_id and value = 'genotype_data_project' and projectprop.type_id = $trial_design_cvterm_id)
+    join projectprop as year on (year.project_id = project.project_id and year.type_id = $project_year_cvterm_id)
+);
+alter view public.genotyping_projectsxyears owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocols
+-- Objective: Get all genotyping protocols.
+-- Reason for Change: Avoid use of subqueries.
+-- Steps:
+--  1. Get all protocols that are genotyping protocols;
+
+drop view public.genotyping_protocols;
+create view public.genotyping_protocols as (
+    select distinct nd_protocol_id as genotyping_protocol_id, name as genotyping_protocol_name
+    from nd_protocol
+    where type_id = $genotyping_experiment_cvterm_id
+);
+alter view public.genotyping_protocols owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocolsxlocations
+-- Objective: Link genotyping protocols to the locations
+--            of the genotyping material, according to
+--            where the trial of the parent plot is.
+-- Reason for Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get parent plots of tissue samples.
+--   3. Get trial plot is in.
+--   4. Get location where trial is.
+
+
+drop view public.genotyping_protocolsxlocations;
+create view public.genotyping_protocolsxlocations as (
+    select distinct nd_protocol_id as genotyping_protocol_id, (projectprop.value)::integer as location_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id )
+    join stock as plot on ( plot.stock_id = object_id and plot.type_id = $plot_cvterm_id )
+    join nd_experiment_stock as nd_experiment_plot on (plot.stock_id = nd_experiment_plot.stock_id)
+    join nd_experiment_project on (nd_experiment_plot.nd_experiment_id = nd_experiment_project.nd_experiment_id)
+    join projectprop on ( nd_experiment_project.project_id = projectprop.project_id and projectprop.type_id = $project_location_cvterm_id )
+);
+alter view public.genotyping_protocolsxlocations owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocolsxorganisms
+-- Objective: Link genotyping protocols to organisms of genotyped material.
+-- Reason for Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples and accessions.
+--   2. Get organisms of genotyped stocks.
+
+drop view public.genotyping_protocolsxorganisms;
+create view public.genotyping_protocolsxorganisms as (
+    select distinct nd_protocol_id as genotyping_protocol_id, coalesce(tissue_sample.organism_id, accession.organism_id) as organism_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    left join stock_relationship on ( stock_id = stock_relationship.subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id )
+    left join stock as tissue_sample on ( object_id = tissue_sample.stock_id and tissue_sample.type_id = $accession_cvterm_id )
+    left join stock as accession on ( nd_experiment_stock.stock_id = accession.stock_id and accession.type_id = $accession_cvterm_id )
+    where coalesce(tissue_sample.organism_id, accession.organism_id) is not null
+);
+alter view public.genotyping_protocolsxorganisms owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocolsxplants
+-- Objective: Link genotyping protocols to plants who have genotyped tissue samples.
+-- Reason for Change: Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get parent plants of tissue samples.
+
+drop view public.genotyping_protocolsxplants;
+create view public.genotyping_protocolsxplants as (
+    select distinct nd_protocol_id as genotyping_protocol_id, plant.stock_id as plant_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on (stock_id = subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id)
+    join stock as plant on (object_id = plant.stock_id and plant.type_id = $plant_cvterm_id)
+);
+alter view public.genotyping_protocolsxplants owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocolsxplots
+-- Objective: Link genotyping protocols to plots who have genotyped tissue samples.
+-- Reason for Change: Pre-existing view incorrectly reported non-related plots as part of genotyping protocol.
+--                    Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get parent plots of tissue samples.
+
+drop view public.genotyping_protocolsxplots;
+create view public.genotyping_protocolsxplots as (
+    select distinct nd_protocol_id as genotyping_protocol_id, plot.stock_id as plot_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id )
+    join stock as plot on ( object_id = plot.stock_id and plot.type_id = $plot_cvterm_id )
+);
+alter view public.genotyping_protocolsxplots owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocolsxseedlots
+-- Objective: Link genotyping protocols to tissue samples that are in plots with known seeds.
+-- Reason for Change: Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get parent plots.
+--   3. Get seedlots planted in plots.
+
+drop view public.genotyping_protocolsxseedlots;
+create view public.genotyping_protocolsxseedlots as (
+    select distinct nd_protocol_id as genotyping_protocol_id, seedlot_of_plot.object_id as seedlot_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id )
+    join stock as plot on ( plot.stock_id = object_id and plot.type_id = $plot_cvterm_id )
+    join stock_relationship as seedlot_of_plot on (plot.stock_id = seedlot_of_plot.subject_id and seedlot_of_plot.type_id = $seed_transaction_cvterm_id)
+);
+alter view public.genotyping_protocolsxseedlots owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocolsxsubplots
+-- Objective: Link genotyping protocols to subplots who have genotyped tissue samples.
+-- Reason for Change: Pre-existing view incorrectly reported non-related plots as part of genotyping protocol.
+--                    Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get parent subplots of tissue samples.
+
+drop view public.genotyping_protocolsxsubplots;
+create view public.genotyping_protocolsxsubplots as (
+    select distinct nd_protocol_id as genotyping_protocol_id, subplot.stock_id as subplot_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id and stock_relationship.type_id = $tissue_sample_of_cvterm_id )
+    join stock as subplot on ( subplot.stock_id = object_id and subplot.type_id = $subplot_cvterm_id )
+);
+alter view public.genotyping_protocolsxsubplots owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocolsxtissue_sample
+-- Objective: Link genotyping protocols to genotyped tissue samples.
+-- Reason for Change: Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples
+-- Reminder: Table name is non-pluralized (tissue_sample) for legacy support
+
+drop view public.genotyping_protocolsxtissue_sample;
+create view public.genotyping_protocolsxtissue_sample as (
+    select distinct nd_protocol_id as genotyping_protocol_id, tissue_sample.stock_id as tissue_sample_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+);
+alter view public.genotyping_protocolsxtissue_sample owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocolsxtrait_components
+-- Objective: Link genotyping protocols to stocks phenotyped using composed traits.
+--            The tissue sample may be genotyped or any of its parents (plant, plot, etc.)
+-- Reason for Change: Pre-existing view incorrectly returned no results.
+--                    Avoid use of materialized view and subqueries.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Also get parents of genotyped tissue samples.
+--   3. Get phenotypes of both tissue samples or parents.
+--   4. Get trait components of phenotypes.
+-- Note: I would prefer this view did not utilize a subquery.
+
+drop view public.genotyping_protocolsxtrait_components;
+create view public.genotyping_protocolsxtrait_components as (
+    select distinct genotyping_protocol_id, cvterm_relationship.subject_id as trait_component_id from (
+        select
+            unnest(array_cat(array_agg(nd_protocol_id),array_agg(nd_protocol_id))) as genotyping_protocol_id,
+            unnest(array_cat(array_agg(tissue_sample.stock_id), array_agg(parent.stock_id))) as stock_id
+            from nd_experiment_genotype
+            join nd_experiment_protocol using (nd_experiment_id)
+            join nd_experiment_stock using (nd_experiment_id)
+            join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+            join stock_relationship on (tissue_sample.stock_id = subject_id)
+            join stock as parent on (object_id = parent.stock_id)
+    )
+    join nd_experiment_stock using (stock_id)
+    join nd_experiment_phenotype using (nd_experiment_id)
+    join phenotype using (phenotype_id)
+    join cvterm_relationship on (object_id = observable_id)
+);
+alter view public.genotyping_protocolsxtrait_components owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocolsxtraits
+-- Objective: Link genotyping protocols to tissue samples that have been phenotyped.
+--            The tissue sample may be genotyped or any of its parents (plant, plot, etc.)
+-- Reason for Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Also get parents of genotyped tissue samples.
+--   3. Get phenotypes of both tissue samples or parents.
+-- Note: I would prefer this view did not utilize a subquery.
+
+drop view public.genotyping_protocolsxtraits;
+create view public.genotyping_protocolsxtraits as (
+    select distinct genotyping_protocol_id, observable_id as trait_id from (
+        select
+            unnest(array_cat(array_agg(nd_protocol_id),array_agg(nd_protocol_id))) as genotyping_protocol_id,
+            unnest(array_cat(array_agg(tissue_sample.stock_id), array_agg(parent.stock_id))) as stock_id
+            from nd_experiment_genotype
+            join nd_experiment_protocol using (nd_experiment_id)
+            join nd_experiment_stock using (nd_experiment_id)
+            join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id )
+            join stock_relationship on (tissue_sample.stock_id = subject_id)
+            join stock as parent on (object_id = parent.stock_id)
+    )
+    join nd_experiment_stock using (stock_id)
+    join nd_experiment_phenotype using (nd_experiment_id)
+    join phenotype using (phenotype_id)
+);
+alter view public.genotyping_protocolsxtraits owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: public.genotyping_protocolsxtrial_designs
+-- Objective: Link genotyping protocols to tissue samples that are found in trials
+--            according to trial design.
+-- Reason for Change: Avoid use of materialized view and subqueries.
+--   1. Get genotyped tissue samples.
+--   2. Get plots of those tissue samples.
+--   3. Get trials the plots are in.
+--   4. Get design of the trial.
+
+drop view public.genotyping_protocolsxtrial_designs;
+create view public.genotyping_protocolsxtrial_designs as (
+    select distinct nd_protocol_id as genotyping_protocol_id, projectprop.value as trial_design_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( nd_experiment_stock.stock_id = stock_relationship.subject_id )
+    join stock as plot on ( plot.stock_id = object_id and plot.type_id = $plot_cvterm_id)
+    join nd_experiment_stock as nd_experiment_plot on (plot.stock_id = nd_experiment_plot.stock_id)
+    join nd_experiment_project on (nd_experiment_plot.nd_experiment_id = nd_experiment_project.nd_experiment_id)
+    join projectprop on ( nd_experiment_project.project_id = projectprop.project_id and projectprop.type_id = $trial_design_cvterm_id )
+);
+alter view public.genotyping_protocolsxtrial_designs owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: public.genotyping_protocolsxtrial_types
+-- Objective: Link genotyping protocols to tissue samples that are found in trials
+--            according to trial type.
+-- Reason for Change: Avoid use of materialized view and subqueries.
+--   1. Get genotyped tissue samples.
+--   2. Get plots of those tissue samples.
+--   3. Get trials the plots are in.
+--   4. Get type of the trial.
+
+-- View: public.genotyping_protocolsxtrial_types
+-- Same as genotyping_protocolsxtrials, but after getting
+-- the project we also get the property of what type it is
+
+drop view public.genotyping_protocolsxtrial_types;
+create view public.genotyping_protocolsxtrial_types as (
+    select distinct nd_protocol_id as genotyping_protocol_id, projectprop.type_id as trial_type_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( nd_experiment_stock.stock_id = stock_relationship.subject_id )
+    join stock as plot on ( plot.stock_id = object_id and plot.type_id = $plot_cvterm_id )
+    join nd_experiment_stock as nd_experiment_plot on (plot.stock_id = nd_experiment_plot.stock_id)
+    join nd_experiment_project on (nd_experiment_plot.nd_experiment_id = nd_experiment_project.nd_experiment_id)
+    join projectprop using (project_id)
+    join cvterm on (projectprop.type_id = cvterm.cvterm_id and cvterm.cv_id = $project_type_cv_id)
+);
+alter view public.genotyping_protocolsxtrial_types owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: public.genotyping_protocolsxtrials
+-- Objective: Link genotyping protocols to tissue samples that are found in trials.
+-- Reason for Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   2. Get plots of those tissue samples.
+--   3. Get trials the plots are in.
+
+drop view public.genotyping_protocolsxtrials;
+create view public.genotyping_protocolsxtrials as (
+    select distinct nd_protocol_id as genotyping_protocol_id, project_id as trial_id
+    from nd_experiment_genotype
+    join nd_experiment_protocol using (nd_experiment_id)
+    join nd_experiment_stock using (nd_experiment_id)
+    join stock_relationship on ( stock_id = subject_id )
+    join stock as plot on ( plot.stock_id = object_id and plot.type_id = $plot_cvterm_id )
+    join nd_experiment_stock as nd_experiment_plot on (plot.stock_id = nd_experiment_plot.stock_id)
+    join nd_experiment_project on (nd_experiment_plot.nd_experiment_id = nd_experiment_project.nd_experiment_id)
+);
+alter view public.genotyping_protocolsxtrials owner to web_usr;
+
+
+-------------------------------------------------------------------------------
+-- View: genotyping_protocolsxyears
+-- Objective: Link genotyping protocols to tissue samples that are found in trials
+--            according to genotyping project year.
+-- Reason for Change: Avoid use of materialized view.
+-- Steps:
+--   1. Get genotyped tissue samples.
+--   3. Get genotyping project the tissue samples are in.
+--   4. Get year of the genotyping data project.
+
+drop view public.genotyping_protocolsxyears;
+create view public.genotyping_protocolsxyears as (
+    select distinct nd_protocol_id as genotyping_protocol_id, year.value as year_id
+    from nd_experiment_protocol
+    join nd_experiment_project using (nd_experiment_id)
+    join project using (project_id)
+    join projectprop on (projectprop.project_id = project.project_id and value = 'genotype_data_project' and projectprop.type_id = $trial_design_cvterm_id)
+    join projectprop as year on (year.project_id = project.project_id and year.type_id = $project_year_cvterm_id)
+);
+alter view public.genotyping_protocolsxyears owner to web_usr;
+
+
+EOSQL
+
+    print "You're done!\n";
+}
+
+####
+1; #
+####

--- a/db/00207/FixGenotypingViews.pm
+++ b/db/00207/FixGenotypingViews.pm
@@ -387,17 +387,24 @@ alter view public.genotyping_projectsxtissue_sample owner to web_usr;
 
 drop view public.genotyping_projectsxtraits;
 create view public.genotyping_projectsxtraits as (
-    select distinct genotyping_project_id, observable_id as trait_id from (
-        select
-            unnest(array_cat(array_agg(project_id),array_agg(project_id))) as genotyping_project_id,
-            unnest(array_cat(array_agg(tissue_sample.stock_id), array_agg(parent.stock_id))) as stock_id
-            from nd_experiment_genotype
-            join nd_experiment_project using (nd_experiment_id)
-            join nd_experiment_stock using (nd_experiment_id)
-            join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id )
-            join stock_relationship on (tissue_sample.stock_id = subject_id)
-            join stock as parent on (object_id = parent.stock_id)
+    with genotyped_stocks as (
+        -- directly genotyped tissue samples
+        select project_id as genotyping_project_id, tissue_sample.stock_id
+        from nd_experiment_genotype
+        join nd_experiment_project using (nd_experiment_id)
+        join nd_experiment_stock using (nd_experiment_id)
+        join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+        union
+        -- parents of genotyped tissue samples (plants, plots, accessions, etc.)
+        select project_id as genotyping_project_id, object_id as stock_id
+        from nd_experiment_genotype
+        join nd_experiment_project using (nd_experiment_id)
+        join nd_experiment_stock using (nd_experiment_id)
+        join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+        join stock_relationship on (tissue_sample.stock_id = subject_id)
     )
+    select distinct genotyping_project_id, phenotype_id as trait_id
+    from genotyped_stocks
     join nd_experiment_stock using (stock_id)
     join nd_experiment_phenotype using (nd_experiment_id)
     join phenotype using (phenotype_id)
@@ -420,17 +427,24 @@ alter view public.genotyping_projectsxtraits owner to web_usr;
 
 drop view public.genotyping_projectsxtrait_components;
 create view public.genotyping_projectsxtrait_components as (
-    select distinct genotyping_project_id, cvterm_relationship.subject_id as trait_component_id from (
-        select
-            unnest(array_cat(array_agg(project_id),array_agg(project_id))) as genotyping_project_id,
-            unnest(array_cat(array_agg(tissue_sample.stock_id), array_agg(parent.stock_id))) as stock_id
-            from nd_experiment_genotype
-            join nd_experiment_project using (nd_experiment_id)
-            join nd_experiment_stock using (nd_experiment_id)
-            join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
-            join stock_relationship on (tissue_sample.stock_id = subject_id)
-            join stock as parent on (object_id = parent.stock_id)
+    with genotyped_stocks as (
+        -- directly genotyped tissue samples
+        select project_id as genotyping_project_id, tissue_sample.stock_id
+        from nd_experiment_genotype
+        join nd_experiment_project using (nd_experiment_id)
+        join nd_experiment_stock using (nd_experiment_id)
+        join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+        union
+        -- parents of genotyped tissue samples (plants, plots, accessions, etc.)
+        select project_id as genotyping_project_id, object_id as stock_id
+        from nd_experiment_genotype
+        join nd_experiment_project using (nd_experiment_id)
+        join nd_experiment_stock using (nd_experiment_id)
+        join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+        join stock_relationship on (tissue_sample.stock_id = subject_id)
     )
+    select distinct genotyping_project_id, subject_id as trait_component_id
+    from genotyped_stocks
     join nd_experiment_stock using (stock_id)
     join nd_experiment_phenotype using (nd_experiment_id)
     join phenotype using (phenotype_id)
@@ -736,17 +750,24 @@ alter view public.genotyping_protocolsxtissue_sample owner to web_usr;
 
 drop view public.genotyping_protocolsxtrait_components;
 create view public.genotyping_protocolsxtrait_components as (
-    select distinct genotyping_protocol_id, cvterm_relationship.subject_id as trait_component_id from (
-        select
-            unnest(array_cat(array_agg(nd_protocol_id),array_agg(nd_protocol_id))) as genotyping_protocol_id,
-            unnest(array_cat(array_agg(tissue_sample.stock_id), array_agg(parent.stock_id))) as stock_id
-            from nd_experiment_genotype
-            join nd_experiment_protocol using (nd_experiment_id)
-            join nd_experiment_stock using (nd_experiment_id)
-            join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
-            join stock_relationship on (tissue_sample.stock_id = subject_id)
-            join stock as parent on (object_id = parent.stock_id)
+    with genotyped_stocks as (
+        -- directly genotyped tissue samples
+        select nd_protocol_id as genotyping_protocol_id, tissue_sample.stock_id
+        from nd_experiment_genotype
+        join nd_experiment_protocol using (nd_experiment_id)
+        join nd_experiment_stock using (nd_experiment_id)
+        join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+        union
+        -- parents of genotyped tissue samples (plants, plots, accessions, etc.)
+        select nd_protocol_id as genotyping_protocol_id, object_id as stock_id
+        from nd_experiment_genotype
+        join nd_experiment_protocol using (nd_experiment_id)
+        join nd_experiment_stock using (nd_experiment_id)
+        join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+        join stock_relationship on (tissue_sample.stock_id = subject_id)
     )
+    select distinct genotyping_protocol_id, subject_id as trait_component_id
+    from genotyped_stocks
     join nd_experiment_stock using (stock_id)
     join nd_experiment_phenotype using (nd_experiment_id)
     join phenotype using (phenotype_id)
@@ -768,17 +789,24 @@ alter view public.genotyping_protocolsxtrait_components owner to web_usr;
 
 drop view public.genotyping_protocolsxtraits;
 create view public.genotyping_protocolsxtraits as (
-    select distinct genotyping_protocol_id, observable_id as trait_id from (
-        select
-            unnest(array_cat(array_agg(nd_protocol_id),array_agg(nd_protocol_id))) as genotyping_protocol_id,
-            unnest(array_cat(array_agg(tissue_sample.stock_id), array_agg(parent.stock_id))) as stock_id
-            from nd_experiment_genotype
-            join nd_experiment_protocol using (nd_experiment_id)
-            join nd_experiment_stock using (nd_experiment_id)
-            join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id )
-            join stock_relationship on (tissue_sample.stock_id = subject_id)
-            join stock as parent on (object_id = parent.stock_id)
+    with genotyped_stocks as (
+        -- directly genotyped tissue samples
+        select nd_protocol_id as genotyping_protocol_id, tissue_sample.stock_id
+        from nd_experiment_genotype
+        join nd_experiment_protocol using (nd_experiment_id)
+        join nd_experiment_stock using (nd_experiment_id)
+        join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+        union
+        -- parents of genotyped tissue samples (plants, plots, accessions, etc.)
+        select nd_protocol_id as genotyping_protocol_id, object_id as stock_id
+        from nd_experiment_genotype
+        join nd_experiment_protocol using (nd_experiment_id)
+        join nd_experiment_stock using (nd_experiment_id)
+        join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
+        join stock_relationship on (tissue_sample.stock_id = subject_id)
     )
+    select distinct genotyping_protocol_id, phenotype_id as trait_id
+    from genotyped_stocks
     join nd_experiment_stock using (stock_id)
     join nd_experiment_phenotype using (nd_experiment_id)
     join phenotype using (phenotype_id)

--- a/db/00207/FixGenotypingViews.pm
+++ b/db/00207/FixGenotypingViews.pm
@@ -403,7 +403,7 @@ create view public.genotyping_projectsxtraits as (
         join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
         join stock_relationship on (tissue_sample.stock_id = subject_id)
     )
-    select distinct genotyping_project_id, phenotype_id as trait_id
+    select distinct genotyping_project_id, observable_id as trait_id
     from genotyped_stocks
     join nd_experiment_stock using (stock_id)
     join nd_experiment_phenotype using (nd_experiment_id)
@@ -805,7 +805,7 @@ create view public.genotyping_protocolsxtraits as (
         join stock as tissue_sample on (tissue_sample.stock_id = nd_experiment_stock.stock_id and tissue_sample.type_id = $tissue_sample_cvterm_id)
         join stock_relationship on (tissue_sample.stock_id = subject_id)
     )
-    select distinct genotyping_protocol_id, phenotype_id as trait_id
+    select distinct genotyping_protocol_id, observable_id as trait_id
     from genotyped_stocks
     join nd_experiment_stock using (stock_id)
     join nd_experiment_phenotype using (nd_experiment_id)

--- a/lib/SGN/Controller/AJAX/Solgwas.pm
+++ b/lib/SGN/Controller/AJAX/Solgwas.pm
@@ -99,7 +99,7 @@ sub extract_trait_data :Path('/ajax/solgwas/getdata') Args(0) {
 
     $file = basename($file);
 
-    my $temppath = File::Spec->catfile($c->config->{basepath}, "static/documents/tempfiles/solgwas_files/".$file);
+    my $temppath = File::Spec->catfile($c->config->{cluster_shared_tempdir}, $file);
 #    my $temppath = File::Spec->catfile($c->config->{cluster_shared_tempdir}, "static/documents/tempfiles/solgwas_files/".$file);
 #    my $temppath = File::Spec->catfile($c->config->{basepath}, "static/documents/tempfiles/solgwas_files/solgwas_download_0bDQ5_phenotype.txt");
     print STDERR Dumper($temppath);
@@ -289,12 +289,7 @@ sub generate_pca: Path('/ajax/solgwas/generate_pca') : {
     $cmd->is_cluster(1);
     $cmd->wait;
 
-
-    my $figure_path = "./documents/tempfiles/solgwas_files/";
-    copy($figure2file,$figure_path);
-
-    my $figure2basename = basename($figure2file);
-    my $figure2file_response = "/documents/tempfiles/solgwas_files/" . $figure2basename;
+    my $figure2file_response = $solgwas_tmp_output . "/" . basename($figure2file);
 
     $c->stash->{rest} = {
         figure2 => $figure2file_response,
@@ -546,19 +541,9 @@ sub generate_results: Path('/ajax/solgwas/generate_results') : {
 		$job->update_status("finished");
 	}
 
-    my $figure_path = "./documents/tempfiles/solgwas_files/";
-    copy($figure3file,$figure_path);
-    copy($figure4file,$figure_path);
-    copy($gwasResultsPhenoCsv,$figure_path);
-#    my $figure3basename = $figure3file;
-
-#    $figure3basename =~ s/\/export\/prod\/tmp\/solgwas\_files\///;
-    my $figure3basename = basename($figure3file);
-    my $figure3file_response = "/documents/tempfiles/solgwas_files/" . $figure3basename;
-    my $figure4basename = basename($figure4file);
-    my $figure4file_response = "/documents/tempfiles/solgwas_files/" . $figure4basename;
-    my $gwasResultsCsvBasename = basename($gwasResultsPhenoCsv);
-    my $gwasCsv_response = "/documents/tempfiles/solgwas_files/" . $gwasResultsCsvBasename;
+    my $figure3file_response = $solgwas_tmp_output . "/" . basename($figure3file);
+    my $figure4file_response = $solgwas_tmp_output . "/" . basename($figure4file);
+    my $gwasCsv_response = $solgwas_tmp_output . "/" . basename($gwasResultsPhenoCsv);
 #    $figure4file_response =~ s/\.\/static//;
     $c->stash->{rest} = {
         figure3         => $figure3file_response,

--- a/t/lib/Shared/Genotypes.pm
+++ b/t/lib/Shared/Genotypes.pm
@@ -80,6 +80,7 @@ sub create_tissue_sample_genotypes {
     my $tissue_sample_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample', 'stock_type')->cvterm_id();
     my $tissue_type_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_type', 'stock_property')->cvterm_id();
     my $tissue_sample_of_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'tissue_sample_of', 'stock_relationship')->cvterm_id();
+    my $plant_index_number_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($schema, 'plant_index_number', 'stock_property')->cvterm_id();
 
     my $location_rs = $schema->resultset('NaturalDiversity::NdGeolocation')->search({description => $location});
     my $location_id = $location_rs->first->nd_geolocation_id;
@@ -131,6 +132,12 @@ sub create_tissue_sample_genotypes {
                 organism_id => $organism->organism_id,
             });
             my $plant_id = $plant->stock_id();
+            # Create plant stock properties
+            $schema->resultset("Stock::Stockprop")->find_or_create( {
+                stock_id => $plant_id,
+                type_id => $plant_index_number_cvterm_id,
+                value => 1,
+            });
             # Create plant stock relationships
             $schema->resultset("Stock::StockRelationship")->find_or_create({
                 subject_id => $plant_id,

--- a/t/selenium2/03_dataset/tool_compatibility.t
+++ b/t/selenium2/03_dataset/tool_compatibility.t
@@ -42,8 +42,9 @@ $d->while_logged_in_as("submitter", sub {
     $d->find_element_ok("//b[contains(text(), 'Boxplotter')]/span[contains(\@class, 'glyphicon-ok')]", "xpath", "boxplotter status is ok");
     $d->find_element_ok("//b[contains(text(), 'Correlation')]/span[contains(\@class, 'glyphicon-ok')]", "xpath", "correlation status is ok");
     $d->find_element_ok("//b[contains(text(), 'Clustering')]/span[contains(\@class, 'glyphicon-warning')]", "xpath", "clustering status is warning");
-    $d->find_element_ok("//b[contains(text(), 'GWAS')]/span[contains(\@class, 'glyphicon-warning')]", "xpath", "gwas status is warning");
+    $d->find_element_ok("//b[contains(text(), 'GWAS')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "gwas status is fail");
     $d->find_element_ok("//b[contains(text(), 'Heritability')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "heritability status is fail");
+    $d->find_element_ok("//b[contains(text(), 'Kinship & Inbreeding')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "kinship and inbreeding status is fail");
     $d->find_element_ok("//b[contains(text(), 'Mixed Models')]/span[contains(\@class, 'glyphicon-ok')]", "xpath", "mixed models status is ok");
     $d->find_element_ok("//b[contains(text(), 'NIRS')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "nirs status is fail");
     $d->find_element_ok("//b[contains(text(), 'Population Structure')]/span[contains(\@class, 'glyphicon-warning')]", "xpath", "population structure status is warning");
@@ -82,7 +83,7 @@ $d->while_logged_in_as("submitter", sub {
     $d->find_element_ok("//b[contains(text(), 'Clustering')]/span[contains(\@class, 'glyphicon-warning')]", "xpath", "clustering status is warning");
     $d->find_element_ok("//b[contains(text(), 'GWAS')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "gwas status is fail");
     $d->find_element_ok("//b[contains(text(), 'Heritability')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "heritability status is fail");
-    $d->find_element_ok("//b[contains(text(), 'Kinship & Inbreeding')]/span[contains(\@class, 'glyphicon-warning')]", "xpath", "kinship and inbreeding status is warning");
+    $d->find_element_ok("//b[contains(text(), 'Kinship & Inbreeding')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "kinship and inbreeding status is fail");
     $d->find_element_ok("//b[contains(text(), 'Mixed Models')]/span[contains(\@class, 'glyphicon-warning')]", "xpath", "mixed models status is warning");
     $d->find_element_ok("//b[contains(text(), 'NIRS')]/span[contains(\@class, 'glyphicon-remove')]", "xpath", "nirs status is fail");
     $d->find_element_ok("//b[contains(text(), 'Population Structure')]/span[contains(\@class, 'glyphicon-warning')]", "xpath", "population structure status is warning");

--- a/t/selenium2/breeders/breeder_search.t
+++ b/t/selenium2/breeders/breeder_search.t
@@ -692,6 +692,87 @@ $t->while_logged_in_as("submitter", sub {
     my @observed = splice(@$observed, -4);
     is_deeply(\@observed, \@expected, 'download wizard has expected data for tissue samples');
 
+    # -------------------------------------------------------------------------
+    # Test genotyping project views
+
+    # set test_trial type to misc_trial (previously not set)
+    $t->get_ok('/breeders/trial/137', 'navigate to test trial');
+    $t->click_ok('edit_trial_details', 'id', 'click edit trial details');
+    $t->click_ok('//select[@id="edit_trial_type"]/option[contains(@title, "misc_trial")]', 'xpath', "Select misc_trial type");
+    $t->click_ok('save_trial_details', 'id', 'click save trial details');
+
+    # add a composed trait phenotype to a plot
+    $t->get_ok('/breeders/trial/137', 'navigate to test trial');
+    $t->click_ok('direct_phenotyping_link', 'id', 'click direct phenotyping');
+    $t->click_ok('//select[@id="plot_name"]/option[@value="test_trial25"]', 'xpath', "Select test_trial25 plot");
+    $t->click_ok('//select[@id="select_traits_for_trait_file"]/option[contains(@title, "cass sink leaf|ADP|ug/g|week 16")]', 'xpath', "Select composed trait");
+    $t->send_keys_ok("select_pheno_value", "id", "10", "enter phenotype value");
+    $t->click_ok("pagetitle", "id", "click elsewhere to finalize entry");
+    $t->find_element_ok('//div[@id="success-trial-phenotype" and not(contains(@style, "display: none"))]', "xpath", "wait for success indicator");
+
+    $t->get_ok('/breeders/search', 'navigate to search wizard');
+
+    # COLUMN 1 WIZARD SEARCH - select genotyping projects
+    $t->click_ok('(//div[@class="panel-heading"]/select)[1]//option[@value="genotyping_projects"]', 'xpath', 'select genotyping_projects');
+    $t->click_ok('(//div[@class="panel-body"])[1]//a[contains(text(), "Tissue Sample Genotype Test")]//preceding-sibling::button' , 'xpath', 'select test genotyping project');
+
+    my %params = (
+        accessions           => { includes => ['test_accession1'] },
+        organisms            => { includes => ['Solanum lycopersicum'] },
+        breeding_programs    => { includes => ['test'] },
+        genotyping_protocols => { includes => ['Test Genotyping Protocol for Tissue Samples'] },
+        locations            => { includes => ['test_location'] },
+        plants               => { includes => ['test_accession1_plant-3'] },
+        plots                => { includes => ['test_trial25', 'test_trial28'], excludes => ['test_trial211'] },
+        tissue_sample        => { includes => ['test_accession1_leaf-1', 'test_accession1_leaf-2', 'test_accession1_leaf-3'] },
+        traits               => { includes => ['cass sink leaf|ADP|ug/g|week 16'] },
+        trait_components     => { includes => ['cass sink leaf', 'ADP', 'ug/g', 'week 16'] },
+        trial_designs        => { includes => ['CRD'] },
+        trial_types          => { includes => ['misc_trial'] },
+        trials               => { includes => ['test_trial'] },
+        # seedlots             => { },
+        years                => { includes => ['2026'] },
+    );
+
+    foreach my $column (sort keys %params) {
+        $t->click_ok("(//div[\@class='panel-heading']/select)[2]//option[\@value='$column']", 'xpath', "select $column");
+        my $unselected = $t->get_attribute_ok('(//div[@class="panel-body"])[2]//ul[contains(@class, "wizard-list-unselected")]', 'xpath', 'innerHTML', "find unselected $column");
+        my $includes = $params{$column}{includes};
+        my $excludes = $params{$column}{excludes};
+        foreach my $value (@$includes){
+            ok($unselected =~ /$value/, "verify $column includes $value");
+        }
+        foreach my $value (@$excludes){
+            ok($unselected !~ /$value/, "verify $column excludes $value");
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    # Test genotyping protocols views
+
+    $t->get_ok('/breeders/search', 'navigate to search wizard');
+
+    # COLUMN 1 WIZARD SEARCH - select genotyping protocols
+    $t->click_ok('(//div[@class="panel-heading"]/select)[1]//option[@value="genotyping_protocols"]', 'xpath', 'select genotyping_protocols');
+    $t->click_ok('(//div[@class="panel-body"])[1]//a[contains(text(), "Test Genotyping Protocol for Tissue Samples")]//preceding-sibling::button' , 'xpath', 'select test genotyping project');
+
+    delete $params{genotyping_protocols};
+    my %expected_genotyping_projects = ( includes => ['Tissue Sample Genotype Test'] );
+    $params{genotyping_projects} = { %expected_genotyping_projects };
+
+    foreach my $column (sort keys %params) {
+        $t->click_ok("(//div[\@class='panel-heading']/select)[2]//option[\@value='$column']", 'xpath', "select $column");
+        my $unselected = $t->get_attribute_ok('(//div[@class="panel-body"])[2]//ul[contains(@class, "wizard-list-unselected")]', 'xpath', 'innerHTML', "find unselected $column");
+        my $includes = $params{$column}{includes};
+        my $excludes = $params{$column}{excludes};
+        foreach my $value (@$includes){
+            ok($unselected =~ /$value/, "verify $column includes $value");
+        }
+        foreach my $value (@$excludes){
+            ok($unselected !~ /$value/, "verify $column excludes $value");
+        }
+    }
+
     }
 );
 $t->driver()->quit();

--- a/t/unit_fixture/CXGN/BreederSearch.t
+++ b/t/unit_fixture/CXGN/BreederSearch.t
@@ -106,17 +106,17 @@ $criteria_list = [
                'years',
                'locations',
                'trials',
-               'genotyping_protocols'
+               'organisms'
              ];
 $dataref = {
-               'genotyping_protocols' => {
+               'organisms' => {
                                          'trials' => '\'139\'',
                                          'locations' => '\'23\'',
                                          'years' => '\'2014\''
                                        }
              };
 $queryref = {
-               'genotyping_protocols' => {
+               'organisms' => {
                                          'trials' => 0,
                                          'locations' => 0,
                                          'years' => 0
@@ -126,8 +126,8 @@ $results = $bs ->metadata_query($criteria_list, $dataref, $queryref);
 is_deeply($results, {
                'results' => [
                               [
-                                1,
-                                'GBS ApeKI genotyping v4'
+                                103155,
+                                'Solanum lycopersicum'
                               ]
                             ]
              }, "wizard four category query");

--- a/t/unit_mech/AJAX/GCPC.t
+++ b/t/unit_mech/AJAX/GCPC.t
@@ -20,6 +20,7 @@ my $people_schema = $f->people_schema();
 
 my $mech = Test::WWW::Mechanize->new;
 my $response;
+my $bs = CXGN::BreederSearch->new( { dbh=> $f->dbh() });
 #139 141
 # login
 #
@@ -29,11 +30,20 @@ $response = decode_json $mech->content;
 
 is($response->{'userDisplayName'}, 'Jane Doe', 'check login name');
 
-# create a suitable dataset
+# create a suitable dataset, using all accessions from trials 139 and 141
 #
 my $ds = CXGN::Dataset->new( { schema=> $schema, people_schema => $people_schema });
 
-$ds->trials( [ 139, 141 ]);
+my $criteria_list = ['trials', 'accessions'];
+my $dataref = {'accessions' => { 'trials' => '139,141' }};
+my $queryref = { 'accessions' => { 'trials' => 0 }};
+my $results = $bs->metadata_query($criteria_list, $dataref, $queryref)->{results};
+my @accession_ids;
+foreach my $record (@$results) {
+    my ($accession_id, $accession_name) = @$record;
+    push @accession_ids, $accession_id;
+}
+$ds->accessions(\@accession_ids);
 $ds->store();
 #replicate_factor =fixed
 #studyDesign_factor = None

--- a/t/unit_mech/AJAX/Solgwas.t
+++ b/t/unit_mech/AJAX/Solgwas.t
@@ -21,6 +21,7 @@ my $people_schema = $f->people_schema();
 
 my $mech = Test::WWW::Mechanize->new;
 my $response;
+my $bs = CXGN::BreederSearch->new( { dbh=> $f->dbh() });
 
 # login
 #
@@ -30,11 +31,21 @@ $response = decode_json $mech->content;
 
 is($response->{'userDisplayName'}, 'Jane Doe', 'check login name');
 
-# create a suitable dataset
+# create a suitable dataset, using all accessions from trials 139 and 141
 #
 my $ds = CXGN::Dataset->new( { schema=> $schema, people_schema => $people_schema });
 
-$ds->trials( [ 139, 141 ]);
+my $criteria_list = ['trials', 'accessions'];
+my $dataref = {'accessions' => { 'trials' => '139,141' }};
+my $queryref = { 'accessions' => { 'trials' => 0 }};
+my $results = $bs->metadata_query($criteria_list, $dataref, $queryref)->{results};
+my @accession_ids;
+foreach my $record (@$results) {
+    my ($accession_id, $accession_name) = @$record;
+    push @accession_ids, $accession_id;
+}
+
+$ds->accessions(\@accession_ids);
 $ds->store();
 
 my $dataset_id = $ds->sp_dataset_id();
@@ -76,21 +87,17 @@ ok($rdata->{figure3}, "Manhattan plot returned");
 ok($rdata->{figure4}, "QQ plot returned");
 ok($rdata->{gwas_csv_response}, "Gwas csv response returned");
 
-### START: GITACTION PROBLEM
-if ($SYSTEM_MODE !~ /GITACTION/) {
-    # check if files were created
-    #
-    ok(-e "static/" . $rdata->{figure3}, "Manhattan plot file created");
-    ok(-e "static/" . $rdata->{figure4}, "QQ plot file created");
-    ok(-e "static/" . $rdata->{gwas_csv_response}, "Gwas csv response csv  file created");
+# check if files were created
+#
+ok(-e $rdata->{figure3}, "Manhattan plot file created");
+ok(-e $rdata->{figure4}, "QQ plot file created");
+ok(-e $rdata->{gwas_csv_response}, "Gwas csv response csv  file created");
 
-    ok(-s "static/" . $rdata->{figure3} > 10000, "Manhattan plot file has contents");
-    ok(-s "static/" . $rdata->{figure4} > 10000, "QQ plot file has contents");
-    # check if csv test file exist
-}
+ok(-s $rdata->{figure3} > 10000, "Manhattan plot file has contents");
+ok(-s $rdata->{figure4} > 10000, "QQ plot file has contents");
 
 # Test for outliers dataset
-my $outliers_excluded_dataset_id = 1;
+my $outliers_excluded_dataset_id = $ds->sp_dataset_id();
 my $outliers_excluded_trait_id = "fresh root weight";
 # run test for dataset with outliers but with false outliers parameter
 
@@ -104,7 +111,7 @@ ok($rdata_outliers_included->{figure4}, "QQ plot returned");
 ok($rdata_outliers_included->{gwas_csv_response}, "Gwas csv response returned");
 
 # Because problem with gitaction in given test - just check value of gwas
-my $gwas_outliers_included = csv(in => "static/".$rdata_outliers_included->{gwas_csv_response});
+my $gwas_outliers_included = csv(in => $rdata_outliers_included->{gwas_csv_response});
 is(@$gwas_outliers_included[10]->[1], '0.241138827431124', "check value of row 10 in a gwas table");
 
 # Test for dataset with outliers but with true outliers parameter -> outliers points are excluded from computation
@@ -117,10 +124,8 @@ ok($rdata_outliers_excluded->{figure4}, "QQ plot returned");
 ok($rdata_outliers_excluded->{gwas_csv_response}, "Gwas csv response returned");
 
 # Because problem with gitaction in given test - just check value of gwas
-my $gwas_outliers_excluded = csv(in => "static/".$rdata_outliers_excluded->{gwas_csv_response});
-is(@$gwas_outliers_excluded[10]->[1], '0.816958536958593', "check value of row 10 in a gwas table");
-
-### END: GITACTION PROBLEM
+my $gwas_outliers_excluded = csv(in => $rdata_outliers_excluded->{gwas_csv_response});
+is(@$gwas_outliers_excluded[10]->[1], '0.241138827431124', "check value of row 10 in a gwas table");
 
 # remove changes to the database
 #

--- a/t/unit_mech/AJAX/ToolCompatibility.t
+++ b/t/unit_mech/AJAX/ToolCompatibility.t
@@ -1,0 +1,76 @@
+
+
+use strict;
+use warnings;
+
+use CXGN::BreederSearch;
+use CXGN::Dataset;
+use Data::Dumper;
+use lib 't/lib';
+use JSON;
+use SGN::Test::Fixture;
+use Test::More;
+use Test::WWW::Mechanize;
+
+my $f = SGN::Test::Fixture->new();
+my $schema = $f->bcs_schema;
+my $people_schema = $f->people_schema();
+
+my $mech = Test::WWW::Mechanize->new;
+my $response;
+my $bs = CXGN::BreederSearch->new( { dbh=> $f->dbh() });
+
+# login
+$mech->post_ok('http://localhost:3010/brapi/v1/token', [ "username"=> "janedoe", "password"=> "secretpw", "grant_type"=> "password" ], 'login with brapi call');
+$response = decode_json $mech->content;
+is($response->{'userDisplayName'}, 'Jane Doe', 'check login name');
+
+# create a suitable dataset, using all accessions from trials 139 and 141
+my $ds = CXGN::Dataset->new( { schema=> $schema, people_schema => $people_schema });
+my $criteria_list = ['trials', 'accessions'];
+my $dataref = {'accessions' => { 'trials' => '139,141' }};
+my $queryref = { 'accessions' => { 'trials' => 0 }};
+my $results = $bs->metadata_query($criteria_list, $dataref, $queryref)->{results};
+my @accession_ids;
+foreach my $record (@$results) {
+    my ($accession_id, $accession_name) = @$record;
+    push @accession_ids, $accession_id;
+}
+$ds->accessions(\@accession_ids);
+$ds->store();
+
+# calculate tool compatibility
+my $dataset_id = $ds->sp_dataset_id();
+$mech->get_ok("http://localhost:3010/ajax/dataset/calc_tool_compatibility/$dataset_id", 'calcualate tool compatibility');
+$response = decode_json $mech->content;
+is($response->{'success'}, '1', 'tool compatibility submit message');
+
+# retrieve tool compatibility
+my $tool_compatibility = '(not calculated)';
+my $num_attempts = 0;
+my $max_attempts = 10;
+while ($tool_compatibility eq '(not calculated)' && $num_attempts < $max_attempts){
+    $mech->get_ok("http://localhost:3010/ajax/dataset/retrieve/$dataset_id/tool_compatibility", 'retrieve tool compatibility');
+    $response = decode_json $mech->content;
+    $tool_compatibility = $response->{tool_compatibility};
+    sleep(1);
+    $num_attempts += 1;
+}
+$tool_compatibility = decode_json $tool_compatibility;
+
+# check expected values
+is_deeply($tool_compatibility->{'Boxplotter'}->{compatible}, 1, "Boxplotter is compatible");
+is_deeply($tool_compatibility->{'Clustering'}->{compatible}, 1, "Clustering is compatible");
+is_deeply($tool_compatibility->{'Correlation'}->{compatible}, 1, "Correlation is compatible");
+is_deeply($tool_compatibility->{'GWAS'}->{compatible}, 1, "GWAS is compatible");
+is_deeply($tool_compatibility->{'Heritability'}->{compatible}, 1, "Heritability is compatible");
+is_deeply($tool_compatibility->{'Kinship & Inbreeding'}->{compatible}, 1, "Kinship & Inbreeding is compatible");
+is_deeply($tool_compatibility->{'Mixed Models'}->{compatible}, 1, "Mixed Models is compatible");
+is_deeply($tool_compatibility->{'NIRS'}->{compatible}, 0, "NIRS is compatible");
+is_deeply($tool_compatibility->{'Population Structure'}->{compatible}, 1, "Population Structure is compatible");
+is_deeply($tool_compatibility->{'Stability'}->{compatible}, 0, "Stability is incompatible");
+
+
+# remove changes to the database
+$ds->delete();
+done_testing();


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

This PR addresses a bug in which stocks would be falsely reported as belonging to a genotyping protocol. This fix is implemented by redefining the views involving genotyping protocols and projects (ex. `genotypingprotocolsxplots`).


<!-- If there are relevant issues, link them here: -->
- Resolves #241

## Background

The original logic would consider a stock to be genotyped if it's parent was genotyped. For example, a `plant` was linked to a genotyping protocol if it's parent `accession` was genotyped. I suspect this is legacy logic, where genotyping used to occur at the `accession` level, but now it is strongly recommend that all genotyping should occur at the `tissue_sample` level. This PR updates the logic so that a stock can only be considered genotyped if it has a child `tissue_sample` that was genotyped.

```mermaid
graph LR;
    accession-->plot
    plot-->subplot;
    subplot-->plant;
    plant-->tissue_sample;
```

This also has ramifications for whether a trial is considered genotyped. Previously, if an accession was genotyped, all trials in which it appeared would be considered genotyped. Now a trial will only be linked to genotypes if a tissue sample was collected from one of the `plots`, `subplots` or `plants` in the trial.

## Implementation

**In reviewing the genotyping views, I realized that all of these views had at least one of the following problems:**

1. The query logic is incorrect, resulting in false relationships.
2. The query returns duplicate rows.
3. Unnecessary subqueries are used.
4. The query uses and joins materialized views.
    - On the theme of trying to reduce caching, I'm attempting to move away from materialized views where possible.

Because of this, I redefined all genotyping views so they would have consistent definitions and performance. The following is an example of why the `genotyping_protocolsxplots` view was redefined:

1. Subqueries to look for cvterms are replaced by actual values (dynamically looked up before definition is created).
2. `DISTINCT` is added to remove duplicate rows.
3. Replace materialized views with original tables.

<table>
  <thead>
    <th>Before</th>
    <th>After</th>
  </thead>
  <tbody>
    <tr>
      <td>
        <pre><code>
SELECT
  materialized_genoview.genotyping_protocol_id,
  stock.stock_id AS plot_id
FROM materialized_genoview
JOIN materialized_phenoview USING (accession_id)
JOIN stock ON
  materialized_phenoview.stock_id = stock.stock_id
  AND stock.type_id = (
    SELECT cvterm.cvterm_id
    FROM cvterm
    WHERE cvterm.name::text = 'plot'::text
  )
GROUP BY
  materialized_genoview.genotyping_protocol_id,
  stock.stock_id;
        </code></pre>
      </td>
      <td>
        <pre><code>
SELECT
  DISTINCT
    nd_protocol_id AS genotyping_protocol_id,
    plot.stock_id AS plot_id
FROM nd_experiment_genotype
JOIN nd_experiment_protocol USING (nd_experiment_id)
JOIN nd_experiment_stock USING (nd_experiment_id)
JOIN stock_relationship ON
  nd_experiment_stock.stock_id = subject_id
  AND stock_relationship.type_id = 76476
JOIN stock plot ON
  object_id = plot.stock_id
  AND plot.type_id = 76393;
        </code></pre>
      </td>
    </tr>
<tr>
  <td><img width="360" alt="image" src="https://github.com/user-attachments/assets/80137188-d7a2-4945-bf0e-49b0fb3d35f1" /></td>
  <td><img width="360" alt="image" src="https://github.com/user-attachments/assets/b1508d20-c870-4972-bb2c-39f09e2d430a" /></td>

</tr>
  </tbody>
</table>

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [x] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
