### PR TITLE
fix(fieldmap): derive bounds directly from dimensions

### DIFF
--- a/js/source/include/fieldmap/contexts/PlotGridContext.tsx
+++ b/js/source/include/fieldmap/contexts/PlotGridContext.tsx
@@ -117,58 +117,15 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
     }, [plotList]);
 
     const bounds = useMemo(() => {
-        if (plotList.length === 0) {
-            return {
-                minCol: 1,
-                maxCol: dimensions.cols || 1,
-                minRow: 1,
-                maxRow: dimensions.rows || 1,
-                numRows: dimensions.rows || 1,
-                numCols: dimensions.cols || 1
-            };
-        }
-        let minCol = Infinity;
-        let minRow = Infinity;
-        let maxCol = -Infinity;
-        let maxRow = -Infinity;
-
-        plotList.forEach(p => {
-            const x = Number(p.observationUnitPosition.positionCoordinateX);
-            const y = Number(p.observationUnitPosition.positionCoordinateY);
-            if (!isNaN(x)) {
-                if (x < minCol) minCol = x;
-                if (x > maxCol) maxCol = x;
-            }
-            if (!isNaN(y)) {
-                if (y < minRow) minRow = y;
-                if (y > maxRow) maxRow = y;
-            }
-        });
-
-        if (minCol === Infinity) minCol = 1;
-        if (maxCol === -Infinity) maxCol = 1;
-        if (minRow === Infinity) minRow = 1;
-        if (maxRow === -Infinity) maxRow = 1;
-
-        let finalMaxCol = maxCol;
-        let finalMaxRow = maxRow;
-
-        if (dimensions.cols > (maxCol - minCol + 1)) {
-            finalMaxCol = minCol + dimensions.cols - 1;
-        }
-        if (dimensions.rows > (maxRow - minRow + 1)) {
-            finalMaxRow = minRow + dimensions.rows - 1;
-        }
-
         return {
-            minCol,
-            maxCol: finalMaxCol,
-            minRow,
-            maxRow: finalMaxRow,
-            numRows: finalMaxRow - minRow + 1,
-            numCols: finalMaxCol - minCol + 1
+            minCol: 1,
+            maxCol: dimensions.cols || 1,
+            minRow: 1,
+            maxRow: dimensions.rows || 1,
+            numRows: dimensions.rows || 1,
+            numCols: dimensions.cols || 1
         };
-    }, [plotList, dimensions]);
+    }, [dimensions]);
 
     /**
      * Computed bounds including borders


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

The fieldmap bounds are being calculated from the minimum/maximum plot coordinates. This does not play nicely when custom dimensions are configured with empty rows and and map is subsequently rotated. The bounds calculation ignores empty space, shifting the plots to the edge of the field.

Deriving bounds directly from the dimensions simplifies the code and makes the rotation behave as expected.

| |Rotated 90°|Rotated 180°|
|-|---------------|--------------|
|Before|<img width="430" height="409" alt="image" src="https://github.com/user-attachments/assets/7537032d-d5d9-4024-9ffe-329904c1f4fb" />|<img width="436" height="410" alt="image" src="https://github.com/user-attachments/assets/76ec475a-3361-45d9-80a1-77bdd018a104" />|
|After|<img width="422" height="408" alt="image" src="https://github.com/user-attachments/assets/d0079675-21f3-4d7a-b71d-eaf7fc7d2194" />|<img width="427" height="401" alt="image" src="https://github.com/user-attachments/assets/11be3a92-1d42-4aa1-8f0b-094ed7b1b207" />|

- Closes #259 
<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
