### PR TITLE
fix(fieldmap): preserve transformed north arrow and secondary axis on layout save

### DIFF
--- a/js/source/include/fieldmap/components/LabelLayer.tsx
+++ b/js/source/include/fieldmap/components/LabelLayer.tsx
@@ -8,10 +8,9 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
     const {
         bounds,
         renderBounds,
-        dimensions,
         gridMatrix,
         overlappingPlots,
-        axisOrientation
+        transformedSecondaryAxis
     } = usePlotGrid();
 
     const {
@@ -19,43 +18,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
         invertCols,
         labelVar,
         labelSize,
-        secondaryAxis,
-        hasSecondaryAxis
     } = useLayoutConfig();
-
-    // Compute the displayed secondary axis values and labels based on the layout configuration
-    const displayedSecondaryAxis = useMemo(() => {
-        if (!hasSecondaryAxis || !secondaryAxis) {
-            return undefined;
-        }
-
-        const getAxisDisplay = (
-            orientation: { source: 'x' | 'y'; reversed: boolean },
-            length: number
-        ) => {
-            const [label, configValues] = orientation.source === 'x' ?
-                [secondaryAxis.xLabel, secondaryAxis.xValues ?? []] :
-                [secondaryAxis.yLabel, secondaryAxis.yValues ?? []];
-
-            const values = Array.from({ length }, (_, i) => {
-                const idx = orientation.reversed ? length - 1 - i : i;
-                return configValues[idx] ?? '';
-            });
-
-            return { label, values };
-        };
-
-        const { cols, rows } = dimensions;
-        const dispX = getAxisDisplay(axisOrientation.x, cols || bounds.numCols);
-        const dispY = getAxisDisplay(axisOrientation.y, rows || bounds.numRows);
-
-        return {
-            xLabel: dispX.label,
-            yLabel: dispY.label,
-            xValues: dispX.values,
-            yValues: dispY.values
-        };
-    }, [hasSecondaryAxis, secondaryAxis, axisOrientation, dimensions, bounds]);
 
     return (
         <g style={{ pointerEvents: 'none' }}>
@@ -77,12 +40,12 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Column Axis Values (Top and Bottom) */}
-            {displayedSecondaryAxis?.xValues?.length && Array.from({ length: bounds.numCols }).map((_, axisIdx) => {
+            {transformedSecondaryAxis?.xValues?.length && Array.from({ length: bounds.numCols }).map((_, axisIdx) => {
                 const colCoord = bounds.minCol + axisIdx;
                 const colIdx = colCoord - renderBounds.minCol;
                 const displayX = (invertCols ? renderBounds.numCols - colIdx - 1 : colIdx) * 52 + 25;
 
-                const axisValue = displayedSecondaryAxis.xValues[axisIdx];
+                const axisValue = transformedSecondaryAxis.xValues?.[axisIdx];
                 if (axisValue === undefined) {
                     return null;
                 }
@@ -100,7 +63,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Column Axis Label */}
-            {displayedSecondaryAxis?.xLabel && (
+            {transformedSecondaryAxis?.xLabel && (
                 <>
                     <text
                         x={(renderBounds.numCols * 52) / 2}
@@ -110,7 +73,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                         fontWeight="bold"
                         fill="#000"
                     >
-                        {displayedSecondaryAxis.xLabel}
+                        {transformedSecondaryAxis.xLabel}
                     </text>
                     <text
                         x={(renderBounds.numCols * 52) / 2}
@@ -120,7 +83,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                         fontWeight="bold"
                         fill="#000"
                     >
-                        {displayedSecondaryAxis.xLabel}
+                        {transformedSecondaryAxis.xLabel}
                     </text>
                 </>
             )}
@@ -148,7 +111,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Row Axis Values (Left and Right) */}
-            {displayedSecondaryAxis?.yValues?.length && gridMatrix.map((_, rowIdx) => {
+            {transformedSecondaryAxis?.yValues?.length && gridMatrix.map((_, rowIdx) => {
                 const rowCoord = renderBounds.minRow + rowIdx;
                 const displayY = invertRows ? rowIdx : renderBounds.numRows - rowIdx - 1;
 
@@ -158,7 +121,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                 }
 
                 const axisIdx = rowCoord - bounds.minRow;
-                const axisValue = displayedSecondaryAxis.yValues[axisIdx];
+                const axisValue = transformedSecondaryAxis.yValues?.[axisIdx];
                 if (axisValue === undefined) {
                     return null;
                 }
@@ -176,7 +139,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
             })}
 
             {/* Secondary Row Axis Label */}
-            {displayedSecondaryAxis?.yLabel && (
+            {transformedSecondaryAxis?.yLabel && (
                 <>
                     <text
                         x={-60}
@@ -187,7 +150,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                         fontWeight="bold"
                         fill="#000"
                     >
-                        {displayedSecondaryAxis.yLabel}
+                        {transformedSecondaryAxis.yLabel}
                     </text>
                     <text
                         x={renderBounds.numCols * 52 + 60}
@@ -198,7 +161,7 @@ export const LabelLayer: React.FC<LabelLayerProps> = ({ }) => {
                         fontWeight="bold"
                         fill="#000"
                     >
-                        {displayedSecondaryAxis.yLabel}
+                        {transformedSecondaryAxis.yLabel}
                     </text>
                 </>
             )}

--- a/js/source/include/fieldmap/components/NorthArrow.tsx
+++ b/js/source/include/fieldmap/components/NorthArrow.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import { usePlotGrid } from '../contexts/PlotGridContext';
 import { useLayoutConfig } from '../contexts/LayoutConfigContext';
 
 interface NorthArrowProps {
@@ -7,17 +6,12 @@ interface NorthArrowProps {
 
 export const NorthArrow: React.FC<NorthArrowProps> = ({ }) => {
     const {
-        isTransposed,
-        mapRotation
-    } = usePlotGrid();
-    const {
         invertRows,
         invertCols,
-        northArrowAngle
+        northArrowAngle: angle
     } = useLayoutConfig();
 
     const northArrowRotation = useMemo(() => {
-        let angle = northArrowAngle + mapRotation;
         if (invertCols && invertRows) {
             return angle + 180;
         } else if (invertCols) {
@@ -25,10 +19,9 @@ export const NorthArrow: React.FC<NorthArrowProps> = ({ }) => {
         } else if (invertRows) {
             return 180 - angle;
         }
-        return angle;
-    }, [northArrowAngle, mapRotation, invertCols, invertRows]);
 
-    if (isTransposed) return null;
+        return angle;
+    }, [angle, invertCols, invertRows]);
 
     return (
         <div

--- a/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
+++ b/js/source/include/fieldmap/contexts/LayoutConfigContext.tsx
@@ -8,10 +8,10 @@ export type ColorVar = 'parity' | 'germplasm' | 'block' | 'family_name' | 'cross
 export type LabelVar = 'plot_number' | 'germplasm' | 'block' | 'family_name' | 'cross_name';
 
 export interface SecondaryAxis {
-    xLabel?: string;
-    yLabel?: string;
-    xValues?: string[];
-    yValues?: string[];
+    readonly xLabel?: string;
+    readonly yLabel?: string;
+    readonly xValues?: string[];
+    readonly yValues?: string[];
 }
 
 export interface LayoutConfigContextType {

--- a/js/source/include/fieldmap/contexts/PlotGridContext.tsx
+++ b/js/source/include/fieldmap/contexts/PlotGridContext.tsx
@@ -30,6 +30,7 @@ export interface PlotGridContextType {
 
     fetchObservationUnits: () => Promise<void>;
     recalculateLayout: (layout: 'serpentine' | 'zigzag') => void;
+    mutatePlot: (plotId: string | Plot, updatedFields: Partial<Plot>) => void;
 
     dimensions: { rows: number; cols: number };
     applyDimensions: (rowsInput: string, colsInput: string, fillerAccessionInput?: string) => Promise<void>;
@@ -354,6 +355,30 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
         }
     }, [activeTrialIds, authToken, setTopBorder, setLeftBorder, setRightBorder, setBottomBorder, setInvertRows, setInvertCols, setPlotLayout, setColorVar, setLabelVar, setLabelSize]);
 
+    const mutatePlot = useCallback((plotRef: string | Plot, updatedFields: Partial<Plot>) => {
+        setPlotObject(current => {
+            const plotId = typeof plotRef === 'string'
+                ? plotRef
+                : plotRef.observationUnitDbId;
+            if (!plotId) {
+                return current;
+            }
+
+            const existingPlot = current[plotId];
+            if (!existingPlot) {
+                return current;
+            }
+
+            return {
+                ...current,
+                [plotId]: {
+                    ...existingPlot,
+                    ...updatedFields
+                }
+            };
+        });
+    }, []);
+
     const applyDimensions = useCallback(async (rowsInput: string, colsInput: string, fillerAccessionInput?: string) => {
         const rows = parseInt(rowsInput) || 0;
         const cols = parseInt(colsInput) || 0;
@@ -450,6 +475,7 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
             plotImages,
             setPlotImages,
             fetchObservationUnits,
+            mutatePlot,
             applyDimensions,
             transformedSecondaryAxis,
         }}>

--- a/js/source/include/fieldmap/contexts/PlotGridContext.tsx
+++ b/js/source/include/fieldmap/contexts/PlotGridContext.tsx
@@ -1,23 +1,23 @@
 import React, { createContext, useContext, useState, useMemo, useCallback, useEffect } from 'react';
 import { Plot, PlotStructureNode } from '../types';
-import { useLayoutConfig } from './LayoutConfigContext';
+import { SecondaryAxis, useLayoutConfig } from './LayoutConfigContext';
 import { FieldMapContextProps } from '../types';
 import { useModals } from './ModalsContext';
 import { useView } from './ViewContext';
 import { derivePlotGrid } from '../utils/derivePlotGrid';
 
 export interface GridBounds {
-    minCol: number;
-    maxCol: number;
-    minRow: number;
-    maxRow: number;
-    numRows: number;
-    numCols: number;
+    readonly minCol: number;
+    readonly maxCol: number;
+    readonly minRow: number;
+    readonly maxRow: number;
+    readonly numRows: number;
+    readonly numCols: number;
 }
 
 export interface AxisOrientation {
-    x: { source: 'x' | 'y'; reversed: boolean };
-    y: { source: 'x' | 'y'; reversed: boolean };
+    readonly x: { source: 'x' | 'y'; reversed: boolean };
+    readonly y: { source: 'x' | 'y'; reversed: boolean };
 }
 
 export interface PlotGridContextType {
@@ -39,9 +39,7 @@ export interface PlotGridContextType {
     fillerAccessionName: string | undefined;
     setFillerAccessionName: React.Dispatch<React.SetStateAction<string | undefined>>;
 
-    isTransposed: boolean;
     transposeLayout: () => void;
-    mapRotation: number;
     rotateLayout: () => void;
     axisOrientation: AxisOrientation;
 
@@ -51,6 +49,8 @@ export interface PlotGridContextType {
     setPlotContentCache: React.Dispatch<React.SetStateAction<Record<string, string[]>>>;
     plotImages: string;
     setPlotImages: React.Dispatch<React.SetStateAction<string>>;
+
+    transformedSecondaryAxis: SecondaryAxis | undefined;
 }
 
 const PlotGridContext = createContext<PlotGridContextType | undefined>(undefined);
@@ -68,6 +68,8 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
         setColorVar,
         setLabelVar,
         setLabelSize,
+        setNorthArrowAngle,
+        secondaryAxis,
         hasSecondaryAxis
     } = useLayoutConfig();
 
@@ -83,8 +85,6 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
     const [dimensions, setDimensions] = useState({ rows: 0, cols: 0 });
     const [fillerAccessionId, setFillerAccessionId] = useState<string | undefined>(undefined);
     const [fillerAccessionName, setFillerAccessionName] = useState<string | undefined>(undefined);
-    const [isTransposed, setIsTransposed] = useState<boolean>(false);
-    const [mapRotation, setMapRotation] = useState<number>(0);
     const [axisOrientation, setAxisOrientation] = useState<AxisOrientation>({
         x: { source: 'x', reversed: false },
         y: { source: 'y', reversed: false }
@@ -158,8 +158,6 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
 
 
     const parsePlotData = useCallback((data: any[]) => {
-        setIsTransposed(false);
-        setMapRotation(0);
         setAxisOrientation({
             x: { source: 'x', reversed: false },
             y: { source: 'y', reversed: false }
@@ -215,12 +213,6 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
     }, [bounds, renderBounds, plotList, fillerAccessionId]);
 
     const recalculateLayout = useCallback((layout: 'serpentine' | 'zigzag', rows?: number, cols?: number) => {
-        setIsTransposed(false);
-        setMapRotation(0);
-        setAxisOrientation({
-            x: { source: 'x', reversed: false },
-            y: { source: 'y', reversed: false }
-        });
         setPlotObject(currentPlots => {
             rows = rows ?? dimensions.rows ?? bounds.numRows;
             cols = cols ?? dimensions.cols ?? bounds.numCols;
@@ -272,7 +264,8 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
     }, [dimensions, bounds]);
 
     const transposeLayout = useCallback(() => {
-        setIsTransposed(t => !t);
+        // Reflection over diagonal (α′ = 2(θ_line) - α) = 2(45) - α = 90 - α
+        setNorthArrowAngle(prev => (90 - prev) % 360);
         setAxisOrientation(prev => ({
             x: prev.y,
             y: prev.x
@@ -295,7 +288,6 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
     }, []);
 
     const rotateLayout = useCallback(() => {
-        setMapRotation(r => (r + 90) % 360);
         setAxisOrientation(prev => ({
             x: prev.y,
             y: {
@@ -303,6 +295,7 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
                 reversed: !prev.x.reversed
             }
         }));
+        setNorthArrowAngle(prev => (prev + 90) % 360);
         const { minCol, maxCol } = bounds;
         setPlotObject(current => {
             const rotated: Record<string, Plot> = {};
@@ -393,6 +386,42 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
         recalculateLayout(plotLayout, rows, cols);
     }, [trialId, plotList]);
 
+    const transformedSecondaryAxis = useMemo(() => {
+        if (!hasSecondaryAxis || !secondaryAxis) {
+            return undefined;
+        }
+
+        const getAxisDisplay = (
+            { source, reversed }: { source: 'x' | 'y'; reversed: boolean },
+            length: number
+        ) => {
+            const [label, configValues] = source === 'x' ?
+                [secondaryAxis.xLabel, secondaryAxis.xValues ?? []] :
+                [secondaryAxis.yLabel, secondaryAxis.yValues ?? []];
+
+            if (!reversed) {
+                return { label, values: configValues };
+            }
+
+            const values = Array.from({ length }, (_, i) => {
+                return configValues[length - 1 - i] ?? '';
+            });
+
+            return { label, values };
+        };
+
+        const { cols, rows } = dimensions;
+        const dispX = getAxisDisplay(axisOrientation.x, cols || bounds.numCols);
+        const dispY = getAxisDisplay(axisOrientation.y, rows || bounds.numRows);
+
+        return {
+            xLabel: dispX.label,
+            yLabel: dispY.label,
+            xValues: dispX.values,
+            yValues: dispY.values
+        };
+    }, [hasSecondaryAxis, secondaryAxis, axisOrientation, dimensions, bounds]);
+
     useEffect(() => {
         fetchObservationUnits();
     }, [activeTrialIds]);
@@ -413,8 +442,6 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
             transposeLayout,
             rotateLayout,
             recalculateLayout,
-            isTransposed,
-            mapRotation,
             axisOrientation,
             plotStructure,
             setPlotStructure,
@@ -424,6 +451,7 @@ export const PlotGridProvider: React.FC<FieldMapContextProps> = ({ trialId, auth
             setPlotImages,
             fetchObservationUnits,
             applyDimensions,
+            transformedSecondaryAxis,
         }}>
             {children}
         </PlotGridContext.Provider>

--- a/js/source/include/fieldmap/hooks/useReplaceAccession.ts
+++ b/js/source/include/fieldmap/hooks/useReplaceAccession.ts
@@ -3,12 +3,18 @@ import { useModals } from '../contexts/ModalsContext';
 import { usePlotGrid } from '../contexts/PlotGridContext';
 import { useView } from '../contexts/ViewContext';
 import { Plot } from '../types';
+import { isDefined } from '../../functions';
 
 export enum ReplaceAccessionResult {
 	Success = 'success',
 	Warning = 'warning',
 	Error = 'error'
 }
+
+type ReplaceAccessionResponseBody =
+    { error: string } |
+    { warning: string } |
+    { success: 1, new_accession_id: string };
 
 export const useReplaceAccession = () => {
 	const {
@@ -20,7 +26,7 @@ export const useReplaceAccession = () => {
 	} = useModals();
 
 	const {
-		fetchObservationUnits
+        mutatePlot
 	} = usePlotGrid();
 
     const replaceAccession = useCallback(async (override: 'check' | 'override', selectedPlot: Plot | null, newAccession: string, newPlotName: string) => {
@@ -39,14 +45,18 @@ export const useReplaceAccession = () => {
                     override: override
                 })
             });
-            const body = await response.json();
-            if (body.warning) {
+            const body: ReplaceAccessionResponseBody = await response.json();
+            if ('warning' in body) {
 				return ReplaceAccessionResult.Warning;
-            } else if (body.error) {
+            } else if ('error' in body) {
                 alert(body.error);
             } else {
                 alert('Plot Accession Replaced successfully!');
-                fetchObservationUnits();
+                mutatePlot(selectedPlot, {
+                    germplasmName: newAccession,
+                    germplasmDbId: body.new_accession_id,
+                    observationUnitName: newPlotName || selectedPlot.observationUnitName,
+                });
 				return ReplaceAccessionResult.Success;
             }
         } catch (e) {
@@ -56,7 +66,7 @@ export const useReplaceAccession = () => {
         }
 
 		return ReplaceAccessionResult.Error;
-    }, [trialId, setLoading, fetchObservationUnits]);
+    }, [trialId, setLoading, mutatePlot]);
 
     return { replaceAccession };
 };

--- a/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
+++ b/js/source/include/fieldmap/hooks/useSubmitFieldLayout.ts
@@ -3,7 +3,7 @@ import { useLayoutConfig } from '../contexts/LayoutConfigContext';
 import { useModals } from '../contexts/ModalsContext';
 import { usePlotGrid } from '../contexts/PlotGridContext';
 import { useView } from '../contexts/ViewContext';
-import { buildParams, isDefined } from '../../functions';
+import { buildParams } from '../../functions';
 
 export const useSubmitFieldLayout = () => {
 	const {
@@ -16,6 +16,7 @@ export const useSubmitFieldLayout = () => {
 		fillerAccessionId,
 		fillerAccessionName,
 		fetchObservationUnits,
+		transformedSecondaryAxis: secondaryAxis
 	} = usePlotGrid();
 
 	const {
@@ -31,7 +32,6 @@ export const useSubmitFieldLayout = () => {
 		labelSize,
 		northArrowAngle,
 		loadNorthArrowAngle,
-		secondaryAxis,
 		loadSecondaryAxis
 	} = useLayoutConfig();
 
@@ -173,7 +173,7 @@ export const useSubmitFieldLayout = () => {
 		trialId, authToken, gridMatrix, invertRows,
 		invertCols, topBorder, leftBorder, rightBorder,
 		bottomBorder, plotLayout, colorVar, labelVar,
-		labelSize, northArrowAngle, secondaryAxis,
+		labelSize, northArrowAngle, secondaryAxis, maxLevelCode,
 		fetchObservationUnits, loadNorthArrowAngle, loadSecondaryAxis, setLoading
 	]);
 

--- a/lib/SGN/Controller/AJAX/TrialMetadata.pm
+++ b/lib/SGN/Controller/AJAX/TrialMetadata.pm
@@ -3173,7 +3173,7 @@ sub replace_plot_accession : Chained('trial') PathPart('replace_plot_accessions'
     my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath});
 
     print STDERR "OldAccession: $old_accession, NewAcc: $new_accession, OldPlotName: $old_plot_name, NewPlotName: $new_plot_name OldPlotId: $plot_id\n";
-    $c->stash->{rest} = { success => 1};
+    $c->stash->{rest} = { success => 1, new_accession_id => $new_accession_id };
 }
 
 sub accession_exists : Chained('trial') PathPart('accession_exists') Args(0) {

--- a/t/unit_mech/AJAX/BreedersToolbox/TrialMetadata.t
+++ b/t/unit_mech/AJAX/BreedersToolbox/TrialMetadata.t
@@ -190,7 +190,7 @@ is_deeply($response, {'success' => 1}, "get add management factor page");
 
 $mech->post_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/replace_plot_accessions', ['old_accession' => 'test_accession3', 'new_accession' => 'test_accession1', 'old_plot_id' => '38866', 'old_plot_name' => 'test_trial210', 'new_plot_name' => "test_trial210_afterchange", 'override' => 'check']);
 $response = decode_json $mech->content;
-is_deeply($response, {success => 1});
+is_deeply($response, {success => 1, new_accession_id => ignore()});
 
 $mech->get_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/plots');
 $response = decode_json $mech->content;
@@ -199,7 +199,7 @@ is_deeply($response, {'plots' => [[[38857,'test_trial21'],[38858,'test_trial22']
 
 $mech->post_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/replace_plot_accessions', ['old_accession' => 'test_accession1', 'new_accession' => 'test_accession3', 'old_plot_id' => '38866', 'old_plot_name' => 'test_trial210_afterchange', 'new_plot_name' => "test_trial210", 'override' => 'check']);
 $response = decode_json $mech->content;
-is_deeply($response, {success => 1});
+is_deeply($response, {success => 1, new_accession_id => ignore()});
 
 $mech->get_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/get_management_regime');
 $response = decode_json $mech->content;

--- a/t/unit_mech/AJAX/BreedersToolbox/TrialMetadata.t
+++ b/t/unit_mech/AJAX/BreedersToolbox/TrialMetadata.t
@@ -190,7 +190,7 @@ is_deeply($response, {'success' => 1}, "get add management factor page");
 
 $mech->post_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/replace_plot_accessions', ['old_accession' => 'test_accession3', 'new_accession' => 'test_accession1', 'old_plot_id' => '38866', 'old_plot_name' => 'test_trial210', 'new_plot_name' => "test_trial210_afterchange", 'override' => 'check']);
 $response = decode_json $mech->content;
-is_deeply($response, {success => 1, new_accession_id => ignore()});
+is_deeply($response, {success => 1, new_accession_id => 38840});
 
 $mech->get_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/plots');
 $response = decode_json $mech->content;
@@ -199,7 +199,7 @@ is_deeply($response, {'plots' => [[[38857,'test_trial21'],[38858,'test_trial22']
 
 $mech->post_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/replace_plot_accessions', ['old_accession' => 'test_accession1', 'new_accession' => 'test_accession3', 'old_plot_id' => '38866', 'old_plot_name' => 'test_trial210_afterchange', 'new_plot_name' => "test_trial210", 'override' => 'check']);
 $response = decode_json $mech->content;
-is_deeply($response, {success => 1, new_accession_id => ignore()});
+is_deeply($response, {success => 1, new_accession_id => 38842});
 
 $mech->get_ok('http://localhost:3010/ajax/breeders/trial/'.$trial_id.'/get_management_regime');
 $response = decode_json $mech->content;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

We now update the north arrow angle and secondary axis configuration when the field map is transformed.

- The north arrow angle configuration is updated immediately on transpose/rotate
- The north arrow is no longer hidden on transpose; it is reflected over the 45° diagonal
- The secondary axis configuration is updated _on layout submit_.
   - This is because axis transformations can be lossy if the configured axis values are longer than the field itself. Thus, we defer making any configuration changes until we have no choice (ie. the user saves the layout).

---
- Closes #264 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
